### PR TITLE
Allow !create <Item.name>

### DIFF
--- a/src/WorldIMPLAdmin.cpp
+++ b/src/WorldIMPLAdmin.cpp
@@ -259,10 +259,14 @@ void World::create_command(Player *cp, const std::string &itemid) {
         script_data_exchangemap dataList;
 
         std::stringstream ss;
+        std::string tempItem;
         ss.str(itemid);
-        ss >> item;
+        ss >> tempItem;
         ss >> quantity;
         ss >> quality;
+
+        // Obtain the ItemID either from stringId or name
+        item = isNumeric(tempItem) ? std::stoi(tempItem) : Data::getIdFromName(tempItem);
 
         while (ss.good()) {
             ss >> data;
@@ -850,7 +854,7 @@ void World::gmhelp_command(Player *cp) {
         if (Config::instance().debug != 0) {
             std::string tmessage = " <> - parameter.  [] - optional.  | = choice.  () = shortcut";
             cp->inform(tmessage);
-            tmessage = "!create <id> [<quantity> [<quality> [[<data_key>=<data_value>] ...]]] creates an item in your "
+            tmessage = "!create <id|itemName> [<quantity> [<quality> [[<data_key>=<data_value>] ...]]] creates an item in your "
                        "inventory.";
             cp->inform(tmessage);
             tmessage = "!jumpto <player> - (!j) teleports you to the player.";
@@ -886,7 +890,7 @@ void World::gmhelp_command(Player *cp) {
         cp->inform(tmessage);
         tmessage = "!broadcast <message> - (!bc) Broadcasts the message <message> to all players IG.";
         cp->inform(tmessage);
-        tmessage = "!create <id> [<quantity> [<quality> [[<data_key>=<data_value>] ...]]] creates an item in your "
+        tmessage = "!create <id|itemName> [<quantity> [<quality> [[<data_key>=<data_value>] ...]]] creates an item in your "
                    "inventory.";
     }
 

--- a/src/data/Data.cpp
+++ b/src/data/Data.cpp
@@ -126,4 +126,17 @@ void preReload() {
     }
 }
 
+auto getIdFromName(const std::string &itemName) -> TYPE_OF_ITEM_ID {
+    TYPE_OF_ITEM_ID item = 0;
+
+    for (const auto &di : items()) {
+        if (di.second.serverName == itemName) {
+            item = di.second.id;
+            break; // Drop out, we found it
+        }
+    }
+
+    return item;
+}
+
 } // namespace Data

--- a/src/data/Data.hpp
+++ b/src/data/Data.hpp
@@ -61,6 +61,7 @@ void reloadScripts();
 void activateTables();
 auto reload() -> bool;
 void preReload();
+auto getIdFromName(const std::string &itemName) -> TYPE_OF_ITEM_ID;
 
 } // namespace Data
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -38,3 +38,7 @@ auto to_direction(uint8_t dir) -> direction {
     }
     return dir_none;
 }
+
+auto isNumeric(const std::string &str) -> bool {
+    return str.find_first_not_of("0123456789") == std::string::npos;
+}

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -24,6 +24,7 @@
 extern auto mypred(char c1, char c2) -> bool;
 extern auto comparestrings_nocase(const std::string &s1, const std::string &s2) -> bool;
 extern auto to_direction(uint8_t dir) -> direction;
+extern auto isNumeric(const std::string& str) -> bool;
 
 template <class T> struct iterator_range {
     [[nodiscard]] auto begin() const -> T { return p.first; }


### PR DESCRIPTION
Work for #66

Adds the ability in `WorldIMPLAdmin.cpp` to use the `Item.<name>` to
create items.

Added new function to `Data.cpp` to lookup the ID via the itemName

Added new function to `utility.cpp` to check if a string is numeric.