### PR TITLE
docker: install build-essential for in-docker building

### DIFF
--- a/.devcontainer/library-scripts/common-debian.sh
+++ b/.devcontainer/library-scripts/common-debian.sh
@@ -112,7 +112,8 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         strace \
         manpages \
         manpages-dev \
-        init-system-helpers"
+        init-system-helpers \
+        build-essential"
         
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
     if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then


### PR DESCRIPTION
This allows to compile the entire server from within the docker.