### PR TITLE
Enable cache for docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ steps.docker-vars.outputs.has-docker-secret == 'true' }}
           tags: ${{ steps.docker-vars.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}


### PR DESCRIPTION
To speed up the builds a bit, this change enables caching for the docker build.