### PR TITLE
Fix vanishing of containers if picked up with full inventory

### DIFF
--- a/src/WorldIMPLItemMoves.cpp
+++ b/src/WorldIMPLItemMoves.cpp
@@ -1311,14 +1311,18 @@ auto World::pickUpItemFromMap(Player *cp, const position &itemPosition) -> bool 
                     freeSlot = cp->backPackContents->getFirstFreeSlot();
                 }
 
-                if (g_item.isContainer() && backpackPresent && freeSlot < cp->backPackContents->getSlotCount()) {
-                    if (g_cont == nullptr) {
-                        g_cont = new Container(g_item.getId());
-                    } else {
-                        closeShowcaseForOthers(cp, g_cont);
-                    }
+                if (g_item.isContainer() && backpackPresent) {
+                    if (freeSlot < cp->backPackContents->getSlotCount()) {
+                        if (g_cont == nullptr) {
+                            g_cont = new Container(g_item.getId());
+                        } else {
+                            closeShowcaseForOthers(cp, g_cont);
+                        }
 
-                    cp->backPackContents->InsertContainer(g_item, g_cont, freeSlot);
+                        cp->backPackContents->InsertContainer(g_item, g_cont, freeSlot);
+                    } else {
+                        NOK = true;
+                    }
                 } else {
                     if (cp->createItem(g_item.getId(), g_item.getNumber(), g_item.getQuality(), &data_map) > 0) {
                         NOK = true;


### PR DESCRIPTION
"If your backpack is full and just spots in the girdle are left free and you pick up a bag/basket with 'p' the bag vanishes."

This PR fixes this issue: The case that there are containers that are picked up while a character has a full inventory and already a backpack was not handled before. Because of that the item was removed from the map but no "NOK" status was set to 'recreate' the removed item;
(Because of that the creation of a new item was triggered but failed silently because the "number of items" is set to 0 for the first container on each field.)