### PR TITLE
Add field GetContainer lua function

### DIFF
--- a/src/map/Field.cpp
+++ b/src/map/Field.cpp
@@ -275,6 +275,14 @@ auto Field::addContainerOnStack(Item item, Container *container) -> bool {
     return false;
 }
 
+auto Field::GetContainer(MAXCOUNTTYPE count) const -> Container * {
+    auto it = containers.find(count);
+    if (it == containers.end()) {
+        return nullptr;
+    }
+    return it->second;
+}
+
 void Field::save(std::ofstream &mapStream, std::ofstream &itemStream, std::ofstream &warpStream,
                  std::ofstream &containerStream) const {
     writeToStream(mapStream, tile);

--- a/src/map/Field.hpp
+++ b/src/map/Field.hpp
@@ -82,6 +82,7 @@ public:
 
     auto addContainerOnStackIfWalkable(Item item, Container *container) -> bool;
     auto addContainerOnStack(Item item, Container *container) -> bool;
+    [[nodiscard]] auto GetContainer(MAXCOUNTTYPE count) const -> Container *;
 
     void age();
 

--- a/src/script/binding/field.cpp
+++ b/src/script/binding/field.cpp
@@ -37,7 +37,8 @@ auto field() -> Binding<Field> {
             .def("isPassable", &Field::isWalkable)
             .def("isWarp", &field_isWarp, luabind::pure_out_value(_2))
             .def("setWarp", &Field::setWarp)
-            .def("removeWarp", &Field::removeWarp);
+            .def("removeWarp", &Field::removeWarp)
+            .def("getContainer", &Field::GetContainer);
 }
 
 } // namespace binding

--- a/src/script/binding/item.cpp
+++ b/src/script/binding/item.cpp
@@ -48,7 +48,8 @@ auto item() -> Binding<Item> {
             .def("setData", (void (Item::*)(const std::string &, const std::string &)) & Item::setData)
             .def("setData", (void (Item::*)(const std::string &, int32_t)) & Item::setData)
             .def("getData", &Item::getData)
-            .def("isLarge", &Item::isLarge);
+            .def("isLarge", &Item::isLarge)
+            .def("isContainer", &Item::isContainer);
 }
 
 } // namespace binding


### PR DESCRIPTION
Adds a function to access container (of items) of fields via Lua: Exposes two new function for LUA:

1) Item:isContainer() -> bool
True if the item is a container-item (based on the database table "container")

2) Field:GetContainer(number) -> container
Returns the container of the field that represents the content of the item (with isContainer = true) where number = Item.number.

Example 1:
If a single container lies on a field, its Item.number is 0 (yes.). Get the field using Item.pos and then use field:GetContainer(Item.number). Always check before that the item is a container and after, that the container is not nil.

Example 2:
It is now possible in the M.LookAtItem(User, Item) to do such a thing:
```Lua
local itemType = Item:getType()
      
if (itemType == scriptItem.field and Item:isContainer()) then
    local f = world:getField(Item.pos)
    local cont = f:getContainer(Item.number)
    if (cont) then
        local wei = cont:weight()
        User:inform("weight: "..tostring(wei), "weight: "..tostring(wei))
    end
end
```

Small finding? Using a container item on a field will not trigger M.UseItem but M.LookAtItem, with itemType set to nondefined.