### PR TITLE
fix: Get code quality checks running in CI

### DIFF
--- a/.github/actions/setup-cpp-build/action.yml
+++ b/.github/actions/setup-cpp-build/action.yml
@@ -1,0 +1,31 @@
+name: 'Setup C++ Build Environment'
+description: 'Install dependencies and generate compile_commands.json for code analysis'
+
+inputs:
+  install-cppcheck:
+    description: 'Whether to install cppcheck'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install build dependencies
+      shell: bash
+      run: |
+        apt-get update
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get -y -qq install build-essential git wget file
+        apt-get -y -qq install libboost-graph-dev libboost-system-dev libpq-dev lua5.2-dev
+        if [ "${{ inputs.install-cppcheck }}" = "true" ]; then
+          apt-get -y -qq install cppcheck
+        fi
+        wget https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.sh -O cmake.sh -q
+        sh cmake.sh --skip-license --prefix=/usr/local
+
+    - name: Generate compile_commands.json
+      shell: bash
+      run: |
+        cmake -B build \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -Wno-dev

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,32 +6,87 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
 
+    container:
+      image: debian:bookworm
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup C++ build environment
+        uses: ./.github/actions/setup-cpp-build
+        with:
+          install-cppcheck: 'true'
 
       - name: Run cppcheck
-        run: tools/run-cppcheck
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JOB_ID: ${{ github.job }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Only check changed files on PRs for fast feedback
+            git diff --name-only origin/${{ github.base_ref }}...HEAD | \
+              grep -E '\.(cpp|hpp|h|cc|hh|cxx|hxx)$' > changed_files.txt || true
+            
+            if [ -s changed_files.txt ]; then
+              echo "Running cppcheck on changed files:"
+              cat changed_files.txt
+              cppcheck --project=build/compile_commands.json \
+                --file-list=changed_files.txt \
+                --enable=warning,performance,portability \
+                -j $(nproc) \
+                --error-exitcode=1 \
+                -q \
+                --suppress=constParameter:src/netinterface/protocol/BBIWIClientCommands.cpp \
+                --suppress=knownConditionTrueFalse:src/Player.cpp
+            else
+              echo "No C++ files changed in this PR"
+            fi
+          else
+            # Full codebase check on pushes to develop/master
+            echo "Running cppcheck on full codebase"
+            cppcheck --project=build/compile_commands.json \
+              --enable=warning,performance,portability \
+              -j $(nproc) \
+              --error-exitcode=1 \
+              -q \
+              --suppress=constParameter:src/netinterface/protocol/BBIWIClientCommands.cpp \
+              --suppress=knownConditionTrueFalse:src/Player.cpp
+          fi
 
-  clang-format:
+  cpp-linter:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Run clang-format
-        run: tools/run-clang-format && git diff --exit-code
-
-  clang-tidy:
-    runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Run clang-tidy
-        run: tools/run-clang-tidy
+      - name: Setup C++ build environment
+        uses: ./.github/actions/setup-cpp-build
+
+      - name: Run cpp-linter
+        uses: cpp-linter/cpp-linter-action@v2
+        id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JOB_ID: ${{ github.job }}
+        with:
+          style: 'file'
+          tidy-checks: ''
+          database: 'build'
+          version: '18'
+          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+          step-summary: true
+          # Only check changed files on PRs for fast feedback
+          # Check all files on pushes to develop/master for comprehensive coverage
+          files-changed-only: ${{ github.event_name == 'pull_request' }}
+          ignore: 'build'
+
+      - name: Fail if linting errors
+        if: steps.linter.outputs.checks-failed > 0
+        run: |
+          echo "Linting failed with ${{ steps.linter.outputs.checks-failed }} errors"
+          exit 1

--- a/tools/run-clang-format
+++ b/tools/run-clang-format
@@ -1,5 +1,5 @@
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 pushd $SCRIPTPATH > /dev/null
-docker-compose -f clang-format.yml pull
-docker-compose -f clang-format.yml run --rm clang-format
+docker compose -f clang-format.yml pull
+docker compose -f clang-format.yml run --rm clang-format
 popd > /dev/null

--- a/tools/run-clang-tidy
+++ b/tools/run-clang-tidy
@@ -5,8 +5,8 @@ pushd $SCRIPTPATH > /dev/null
 [ -z "$CI" ] || mkdir -p /tmp/build
 [ -z "$CI" ] && BIND_BUILD="build:/build" || BIND_BUILD="/tmp/build:/build"
 
-docker-compose -f clang-tidy.yml pull
-docker-compose -f clang-tidy.yml run --rm -v $BIND_BUILD clang-tidy
+docker compose -f clang-tidy.yml pull
+docker compose -f clang-tidy.yml run --rm -v $BIND_BUILD clang-tidy
 exit_code=$?
 
 # Add check-run annotations on GitHub

--- a/tools/run-cppcheck
+++ b/tools/run-cppcheck
@@ -5,8 +5,8 @@ pushd $SCRIPTPATH > /dev/null
 [ -z "$CI" ] || XML="--xml --xml-version=2 --output-file=/tmp/cppcheck.xml"
 [ -z "$CI" ] || BIND_TMP="-v /tmp:/tmp"
 
-docker-compose -f cppcheck.yml pull
-docker-compose -f cppcheck.yml run --rm $BIND_TMP cppcheck sh -c "cppcheck --std=c++20 --enable=warning,style,performance,portability --inconclusive -j $(nproc) $XML --error-exitcode=1 -q --suppress=constParameter:src/netinterface/protocol/BBIWIClientCommands.cpp --suppress=knownConditionTrueFalse:src/Player.cpp -Isrc/ src/"
+docker compose -f cppcheck.yml pull
+docker compose -f cppcheck.yml run --rm $BIND_TMP cppcheck sh -c "cppcheck --std=c++20 --enable=warning,style,performance,portability --inconclusive -j $(nproc) $XML --error-exitcode=1 -q --suppress=constParameter:src/netinterface/protocol/BBIWIClientCommands.cpp --suppress=knownConditionTrueFalse:src/Player.cpp -Isrc/ src/"
 exit_code=$?
 
 # Print XML output and add check-run annotations on GitHub


### PR DESCRIPTION
## Intent

This changeset fixes the `cppcheck` CI workflow, and replaces `clang-tidy` and `clang-format` with a single `cpp-linter` action. Both of these changes move CI actions out of Docker.

I also did some work to try to optimize the workflows; only changes relevant to a PR will be linted/analyzed, but the entire codebase is analyzed on pushes to `develop` and `master`.