### PR TITLE
Add Doxygen documentation to the codebase

### DIFF
--- a/src/Attribute.hpp
+++ b/src/Attribute.hpp
@@ -21,24 +21,84 @@
 #ifndef ATTRIBUTE_HPP
 #define ATTRIBUTE_HPP
 
+/**
+ * @brief Represents a character attribute with base value, offset, and maximum.
+ *
+ * This class manages game character attributes (like strength, dexterity, etc.)
+ * with support for temporary modifiers via offsets. The effective value is
+ * calculated as base value + offset, clamped to the maximum.
+ */
 class Attribute {
 public:
-    using attribute_t = unsigned short;
+    using attribute_t = unsigned short; ///< The underlying type for attribute values.
 
 private:
-    attribute_t baseValue{0};
-    int offset{0};
-    attribute_t maximum{0};
+    attribute_t baseValue{0}; ///< The permanent base value of the attribute.
+    int offset{0}; ///< Temporary modifier applied to the base value.
+    attribute_t maximum{0}; ///< The maximum allowed value for this attribute.
 
 public:
+    /**
+     * @brief Default constructor initializing all values to zero.
+     */
     Attribute() = default;
+
+    /**
+     * @brief Constructs an attribute with a specific value and no maximum.
+     * @param value The initial base value for the attribute.
+     */
     explicit Attribute(attribute_t value);
+
+    /**
+     * @brief Constructs an attribute with a value and maximum limit.
+     * @param value The initial base value for the attribute.
+     * @param maximum The maximum allowed value for the attribute.
+     */
     Attribute(attribute_t value, attribute_t maximum);
+
+    /**
+     * @brief Sets the base value of the attribute.
+     * @param value The new base value to set.
+     * @note If a maximum is set and value exceeds it, baseValue is clamped to maximum.
+     */
     void setBaseValue(attribute_t value);
+
+    /**
+     * @brief Sets the effective value by adjusting the offset.
+     *
+     * This modifies the offset so that base + offset equals the desired value.
+     * If baseValue is 0, sets baseValue directly instead of using offset.
+     *
+     * @param value The desired effective value.
+     * @note Values are clamped to maximum if set. Negative values are clamped to 0.
+     */
     void setValue(attribute_t value);
+
+    /**
+     * @brief Gets the base value without any offsets applied.
+     * @return The base value of the attribute.
+     */
     [[nodiscard]] auto getBaseValue() const -> attribute_t;
+
+    /**
+     * @brief Gets the effective value (base + offset), clamped to valid range.
+     * @return The current effective value of the attribute.
+     * @note Returns 0 if the calculated value is negative, or maximum if exceeding the max.
+     */
     [[nodiscard]] auto getValue() const -> attribute_t;
+
+    /**
+     * @brief Increases the base value by the specified amount.
+     * @param amount The amount to add to the base value (can be negative).
+     * @note Result is clamped to [0, maximum]. If maximum is 0 (unset), only lower bound applies.
+     */
     void increaseBaseValue(int amount);
+
+    /**
+     * @brief Increases the effective value by modifying the offset.
+     * @param amount The amount to add to the current value (can be negative).
+     * @note Result is clamped to [0, maximum]. If maximum is 0 (unset), only lower bound applies.
+     */
     void increaseValue(int amount);
 };
 

--- a/src/Character.hpp
+++ b/src/Character.hpp
@@ -48,66 +48,127 @@ class Field;
 }
 class Player;
 
+/**
+ * @brief Magic school types available in the game
+ */
 enum magic_type { MAGE = 0, PRIEST = 1, BARD = 2, DRUID = 3 };
 
+/**
+ * @brief Exception thrown when no loot items are found on a character
+ */
 class NoLootFound : public std::exception {};
 
+/**
+ * @brief Represents a skill value with major and minor components
+ * 
+ * Skills are stored as major (main skill level) and minor (experience points
+ * toward next level) values.
+ */
 struct SkillValue {
-    int major = 0;
-    int minor = 0;
+    int major = 0; ///< Main skill level (0-100)
+    int minor = 0; ///< Experience points toward next major level
 };
 
+/**
+ * @brief Abstract base class for all character types in the game
+ * 
+ * Character is the foundation for Players, NPCs, and Monsters. It manages:
+ * - Character attributes (strength, dexterity, constitution, etc.)
+ * - Inventory system (equipped items, belt, backpack, depots)
+ * - Skills and magic abilities
+ * - Position, movement, and pathfinding
+ * - Combat and health management
+ * - Long-term effects and status conditions
+ * - Dialog system integration
+ * - Action points and fight points for turn-based mechanics
+ * 
+ * @note This is an abstract class - use Player, Monster, or NPC subclasses
+ * @note Character objects are non-copyable but movable
+ */
 class Character {
 public:
+    /**
+     * @brief Character visual appearance settings
+     */
     struct appearance {
-        uint8_t hairtype = 0;
-        uint8_t beardtype = 0;
-        Colour hair;
-        Colour skin;
+        uint8_t hairtype = 0;  ///< Hair style ID
+        uint8_t beardtype = 0; ///< Beard style ID (0 = no beard)
+        Colour hair;           ///< Hair color
+        Colour skin;           ///< Skin color
 
         appearance() = default;
     };
 
+    /**
+     * @brief Default constructor - creates character with default appearance
+     */
     Character();
+
+    /**
+     * @brief Constructs character with specific appearance
+     * @param appearance Initial appearance settings
+     */
     explicit Character(const appearance &appearance);
+
+    /**
+     * @brief Virtual destructor - cleans up backpack and depot containers
+     */
     virtual ~Character();
+
     Character(const Character &) = delete;
     auto operator=(const Character &) -> Character & = delete;
     Character(Character &&) = default;
     auto operator=(Character &&) -> Character & = default;
 
+    /**
+     * @brief Type of character entity
+     */
     enum character_type { player = 0, monster = 1, npc = 2 };
 
+    /**
+     * @brief Character attribute indices
+     * 
+     * Defines all character attributes including stats, vitals, and descriptors.
+     */
     enum attributeIndex {
-        strength,
-        dexterity,
-        constitution,
-        agility,
-        intelligence,
-        perception,
-        willpower,
-        essence,
-        hitpoints,
-        mana,
-        foodlevel,
-        sex,
-        age,
-        weight,
-        height,
-        attitude,
-        luck,
-        ATTRIBUTECOUNT
+        strength,      ///< Physical power
+        dexterity,     ///< Fine motor control and precision
+        constitution,  ///< Physical resilience and health
+        agility,       ///< Speed and reflexes
+        intelligence,  ///< Mental capacity and magic power
+        perception,    ///< Awareness and sensory acuity
+        willpower,     ///< Mental fortitude and resistance
+        essence,       ///< Magical essence and mana regeneration
+        hitpoints,     ///< Current health points
+        mana,          ///< Current magic points
+        foodlevel,     ///< Current satiation level
+        sex,           ///< Character gender (0=male, 1=female)
+        age,           ///< Character age in years
+        weight,        ///< Character body weight
+        height,        ///< Character body height
+        attitude,      ///< Disposition toward other characters
+        luck,          ///< Random event modifier
+        ATTRIBUTECOUNT ///< Total number of attributes
     };
 
     using attribute_map_t = std::unordered_map<std::string, attributeIndex>;
     using attribute_string_map_t = std::unordered_map<attributeIndex, std::string, std::hash<int>>;
-    static attribute_map_t attributeMap;
-    static attribute_string_map_t attributeStringMap;
+    static attribute_map_t attributeMap;          ///< Maps attribute names to indices
+    static attribute_string_map_t attributeStringMap; ///< Maps attribute indices to names
 
+    /**
+     * @brief Speech range types
+     */
     enum talk_type { tt_say = 0, tt_whisper = 1, tt_yell = 2 };
 
+    /**
+     * @brief Biological sex
+     */
     enum sex_type { male = 0, female = 1 };
 
+    /**
+     * @brief Direction the character is facing
+     */
     enum face_to {
         north = dir_north,
         northeast = dir_northeast,
@@ -119,75 +180,232 @@ public:
         northwest = dir_northwest
     };
 
+    /**
+     * @brief Message priority levels for inform() method
+     */
     enum informType {
-        informServer = 0,
-        informBroadcast = 1,
-        informGM = 2,
-        informScriptLowPriority = 100,
-        informScriptMediumPriority = 101,
-        informScriptHighPriority = 102
+        informServer = 0,              ///< Server message
+        informBroadcast = 1,           ///< Broadcast to all players
+        informGM = 2,                  ///< GM-only message
+        informScriptLowPriority = 100,    ///< Low priority script message
+        informScriptMediumPriority = 101, ///< Medium priority script message
+        informScriptHighPriority = 102    ///< High priority script message
     };
 
     using skillvalue = SkillValue;
 
+    /**
+     * @brief Magic school configuration and learned spells
+     */
     struct s_magic {
-        magic_type type;
-        std::array<unsigned long int, 4> flags;
+        magic_type type;                       ///< Current active magic school
+        std::array<unsigned long int, 4> flags; ///< Bitflags for learned spells per school
     };
 
+    /**
+     * @brief Gets the unique character ID
+     * @return Character's ID
+     */
     virtual auto getId() const -> TYPE_OF_CHARACTER_ID;
+
+    /**
+     * @brief Gets the character's name
+     * @return Reference to character name string
+     */
     auto getName() const -> const std::string &;
+
+    /**
+     * @brief Gets string representation of the character
+     * @return String describing the character (pure virtual)
+     */
     virtual auto to_string() const -> std::string = 0;
 
-    static constexpr auto actionPointUnit = 100;
+    static constexpr auto actionPointUnit = 100; ///< Base unit for action point calculations
 
+    // Action Points system
+    /**
+     * @brief Gets current action points
+     * @return Current AP value
+     */
     auto getActionPoints() const -> int;
+
+    /**
+     * @brief Gets minimum possible action points
+     * @return Minimum AP value (can be overridden by subclasses)
+     */
     virtual auto getMinActionPoints() const -> int;
+
+    /**
+     * @brief Gets maximum possible action points
+     * @return Maximum AP value (can be overridden by subclasses)
+     */
     virtual auto getMaxActionPoints() const -> int;
+
+    /**
+     * @brief Sets action points, clamping to maximum
+     * @param ap New action point value
+     */
     void setActionPoints(int ap);
+
+    /**
+     * @brief Increases action points by amount
+     * @param ap Amount to add (can be negative)
+     */
     void increaseActionPoints(int ap);
+
+    /**
+     * @brief Checks if character can perform actions
+     * @return True if AP >= max AP
+     */
     auto canAct() const -> bool;
 
+    // Fight Points system
+    /**
+     * @brief Gets current fight points
+     * @return Current FP value
+     */
     auto getFightPoints() const -> int;
+
+    /**
+     * @brief Gets minimum fight points needed for combat
+     * @return Minimum FP value (can be overridden)
+     */
     virtual auto getMinFightPoints() const -> int;
+
+    /**
+     * @brief Gets maximum possible fight points
+     * @return Maximum FP value (can be overridden)
+     */
     virtual auto getMaxFightPoints() const -> int;
+
+    /**
+     * @brief Sets fight points, clamping to maximum
+     * @param fp New fight point value
+     */
     void setFightPoints(int fp);
+
+    /**
+     * @brief Increases fight points by amount
+     * @param fp Amount to add (can be negative)
+     */
     void increaseFightPoints(int fp);
+
+    /**
+     * @brief Checks if character can engage in combat
+     * @return True if FP >= min FP
+     */
     auto canFight() const -> bool;
 
+    /**
+     * @brief Gets character movement speed multiplier
+     * @return Speed factor (1.0 = normal)
+     */
     auto getSpeed() const -> double;
+
+    /**
+     * @brief Sets character movement speed multiplier
+     * @param spd Speed factor
+     */
     void setSpeed(double spd);
 
+    /**
+     * @brief Gets currently active language for speech
+     * @return Language ID
+     */
     auto getActiveLanguage() const -> short int;
+
+    /**
+     * @brief Sets active language for character speech
+     * @param l Language ID
+     */
     void setActiveLanguage(short int l);
 
+    /**
+     * @brief Gets current world position
+     * @return Reference to position coordinates
+     */
     virtual auto getPosition() const -> const position &;
 
+    /**
+     * @brief Checks if character is in attack mode
+     * @return True if in attack mode
+     */
     auto getAttackMode() const -> bool;
+
+    /**
+     * @brief Sets attack mode state
+     * @param attack True to enable attack mode
+     */
     void setAttackMode(bool attack);
 
+    /**
+     * @brief Gets the last text spoken by this character
+     * @return Reference to last spoken message
+     */
     auto getLastSpokenText() const -> const std::string &;
 
+    /**
+     * @brief Checks if character is invisible to others
+     * @return True if invisible
+     */
     auto isInvisible() const -> bool;
+
+    /**
+     * @brief Sets character invisibility
+     * @param invisible True to make invisible
+     */
     void setInvisible(bool invisible);
 
-    LongTimeCharacterEffects effects;
-    WaypointList waypoints;
+    LongTimeCharacterEffects effects; ///< Active long-term status effects
+    WaypointList waypoints;          ///< Pathfinding waypoint queue
 
+    /**
+     * @brief Gets position directly in front of character
+     * @return Position one tile ahead in facing direction
+     */
     auto getFrontalPosition() const -> position;
 
+    /**
+     * @brief Checks if a long-term action is currently running
+     * @return True if action active (overridden by Player)
+     */
     virtual auto actionRunning() const -> bool { return false; }
 
+    /**
+     * @brief Gets active magic school type
+     * @return Magic type (MAGE, PRIEST, BARD, DRUID)
+     */
     inline auto getMagicType() const -> unsigned short { return magic.type; }
 
+    /**
+     * @brief Sets active magic school
+     * @param newMagType New magic type
+     */
     inline virtual void setMagicType(magic_type newMagType) { magic.type = newMagType; }
 
+    /**
+     * @brief Sets whether character is following a route
+     * @param onr True if on route
+     */
     void setOnRoute(bool onr) { _is_on_route = onr; }
 
+    /**
+     * @brief Checks if character is following a route
+     * @return True if on route
+     */
     auto getOnRoute() const -> bool { return _is_on_route; }
 
+    /**
+     * @brief Gets player's preferred language (overridden by Player)
+     * @return Language enum (default: English for NPCs/Monsters)
+     */
     virtual auto getPlayerLanguage() const -> Language { return Language::english; }
 
+    /**
+     * @brief Gets magic flags for a specific magic school
+     * @param type Magic school (0-3: MAGE, PRIEST, BARD, DRUID)
+     * @return Bitflags representing learned spells, or 0 if invalid type
+     */
     inline auto getMagicFlags(unsigned char type) const -> unsigned long int {
         if (type < 4) {
             return magic.flags.at(type);
@@ -195,320 +413,1083 @@ public:
         return 0;
     }
 
+    /**
+     * @brief Gets character type (pure virtual)
+     * @return Character type identifier
+     */
     virtual auto getType() const -> unsigned short = 0;
 
+    /**
+     * @brief Changes character's race and updates appearance
+     * @param race New race ID
+     */
     virtual void changeRace(TYPE_OF_RACE_ID race) {
         this->race = race;
         updateAppearanceForAll(true);
     }
 
+    /**
+     * @brief Gets character's race
+     * @return Race ID
+     */
     virtual auto getRace() const -> TYPE_OF_RACE_ID { return race; }
 
+    /**
+     * @brief Gets direction character is facing
+     * @return Face direction enum value
+     */
     virtual auto getFaceTo() const -> face_to { return faceto; }
 
+    /**
+     * @brief Checks if character has admin privileges
+     * @return True if admin (overridden by Player)
+     */
     virtual auto isAdmin() const -> bool { return false; }
 
+    /**
+     * @brief Gets monster type ID
+     * @return Monster type (0 for non-monsters, overridden by Monster)
+     */
     virtual auto getMonsterType() const -> TYPE_OF_CHARACTER_ID { return 0; }
 
+    /**
+     * @brief Changes quality of item at specific position
+     * @param pos Item position index
+     * @param amount Amount to change quality by (can be negative)
+     */
     virtual void changeQualityAt(unsigned char pos, int amount);
+
+    /**
+     * @brief Increases poison value on character
+     * @param value Amount to increase poison by
+     */
     virtual void increasePoisonValue(int value);
 
+    /**
+     * @brief Gets current poison level
+     * @return Poison value
+     */
     virtual auto getPoisonValue() const -> int { return poisonvalue; }
 
+    /**
+     * @brief Sets poison level
+     * @param value New poison value
+     */
     virtual void setPoisonValue(int value) { poisonvalue = value; }
 
     /**
-     * starts a new longtime action for this character (overloaded in Player)
-     * <b>Lua: [:startAction]</b>
-     * @param wait time to wait until the action is successfull
-     * @param ani the animation which should be shown for this action, if not set this value is 0
-     * @param redoani after how much 1/10s the animation should be shown again, if not set this value is 0 (0 never)
-     * @param sound the sound which should be played for this action, if not set this value is 0
-     * @param redosound after hoch much 1/10s the sound is played again, if not set this value is 0, 0 means never
+     * @brief Starts a long-time action for this character
+     * 
+     * Overloaded in Player to display action UI.
+     * 
+     * @param wait Time to wait until action succeeds (in 1/10 seconds)
+     * @param ani Animation ID to display (0 = none)
+     * @param redoani How often to repeat animation in 1/10s (0 = once)
+     * @param sound Sound ID to play (0 = none)
+     * @param redosound How often to repeat sound in 1/10s (0 = once)
+     * @note Lua binding: [:startAction]
      */
     inline virtual void startAction(unsigned short int wait, unsigned short int ani = 0, unsigned short int redoani = 0,
                                     unsigned short int sound = 0, unsigned short int redosound = 0) {}
 
+    /**
+     * @brief Aborts current long-time action
+     */
     inline virtual void abortAction() {}
 
+    /**
+     * @brief Marks current action as successful
+     */
     inline virtual void successAction() {}
 
+    /**
+     * @brief Called when action is disturbed by another character
+     * @param disturber Character that caused disturbance
+     */
     inline virtual void actionDisturbed(Character *disturber) {}
 
+    /**
+     * @brief Changes source context to another character
+     * @param cc Source character
+     */
     inline virtual void changeSource(Character *cc) {}
 
+    /**
+     * @brief Changes source context to a script item
+     * @param sI Source script item
+     */
     inline virtual void changeSource(const ScriptItem &sI) {}
 
+    /**
+     * @brief Changes source context to a position
+     * @param pos Source position
+     */
     inline virtual void changeSource(const position &pos) {}
 
+    /**
+     * @brief Changes source context to speech
+     * @param text Speech text
+     * @param talkType Type of speech
+     */
     inline virtual void changeSource(const std::string &text, talk_type talkType) {}
 
+    /**
+     * @brief Clears source context
+     */
     inline virtual void changeSource() {}
 
+    /**
+     * @brief Gets current mental capacity
+     * @return Mental capacity value
+     */
     virtual auto getMentalCapacity() const -> int { return mental_capacity; }
 
+    /**
+     * @brief Sets mental capacity
+     * @param value New mental capacity
+     */
     virtual void setMentalCapacity(int value) { mental_capacity = value; }
 
+    /**
+     * @brief Increases mental capacity by amount
+     * @param value Amount to increase
+     */
     virtual void increaseMentalCapacity(int value);
 
+    // Inventory management
+    /**
+     * @brief Counts total items of specific type
+     * @param itemid Item ID to count
+     * @return Total count across all inventory slots and backpack
+     */
     virtual auto countItem(TYPE_OF_ITEM_ID itemid) const -> int;
-    // where determines where the items will be counted ("all", "belt", "body", "backpack")
-    auto countItemAt(const std::string &where, TYPE_OF_ITEM_ID itemid,
-                     script_data_exchangemap const *data = nullptr) const -> int;
-    virtual auto eraseItem(TYPE_OF_ITEM_ID itemid, int count, script_data_exchangemap const *data = nullptr) -> int;
-    virtual auto createItem(Item::id_type id, Item::number_type number, Item::quality_type quality,
-                            script_data_exchangemap const *data) -> int;
-    virtual auto increaseAtPos(unsigned char pos, int count) -> int;
-    virtual auto createAtPos(unsigned char pos, TYPE_OF_ITEM_ID newid, int count) -> int;
-    virtual auto swapAtPos(unsigned char pos, TYPE_OF_ITEM_ID newid, int newQuality = 0) -> bool;
-    virtual auto GetItemAt(unsigned char itempos) -> ScriptItem;
-    virtual auto GetBackPack() const -> Container *;
-    auto GetDepot(uint32_t depotid) const -> Container *;
-    auto getItemList(TYPE_OF_ITEM_ID id) -> std::vector<ScriptItem>;
-
-    virtual auto getSkillName(TYPE_OF_SKILL_ID s) const -> std::string;
-    virtual auto getSkill(TYPE_OF_SKILL_ID s) const -> unsigned short int;
-    virtual auto getSkillValue(TYPE_OF_SKILL_ID s) const -> const skillvalue *;
-    virtual auto getMinorSkill(TYPE_OF_SKILL_ID s) const -> unsigned short int;
-
-    void setSkinColour(const Colour &c);
-    auto getSkinColour() const -> Colour;
-    void setHairColour(const Colour &c);
-    auto getHairColour() const -> Colour;
-    void setHair(uint8_t hairID);
-    auto getHair() const -> uint8_t;
-    void setBeard(uint8_t beardID);
-    auto getBeard() const -> uint8_t;
-
-    auto getAppearance() const -> appearance { return _appearance; }
-
-    auto setBaseAttribute(Character::attributeIndex attribute, Attribute::attribute_t value) -> bool;
-    void setAttribute(Character::attributeIndex attribute, Attribute::attribute_t value);
-    auto getBaseAttribute(Character::attributeIndex attribute) const -> Attribute::attribute_t;
-    auto getAttribute(Character::attributeIndex attribute) const -> Attribute::attribute_t;
-    auto increaseBaseAttribute(Character::attributeIndex attribute, int amount) -> bool;
-    auto increaseAttribute(Character::attributeIndex attribute, int amount) -> Attribute::attribute_t;
-    auto isBaseAttributeValid(Character::attributeIndex attribute, Attribute::attribute_t value) const -> bool;
-    auto getBaseAttributeSum() const -> uint16_t;
-    auto getMaxAttributePoints() const -> uint16_t;
-    virtual auto saveBaseAttributes() -> bool;
-    virtual void handleAttributeChange(Character::attributeIndex attribute);
-    auto isBaseAttribValid(const std::string &name, Attribute::attribute_t value) const -> bool;
-    auto setBaseAttrib(const std::string &name, Attribute::attribute_t value) -> bool;
-    void setAttrib(const std::string &name, Attribute::attribute_t value);
-    auto getBaseAttrib(const std::string &name) const -> Attribute::attribute_t;
-    auto increaseBaseAttrib(const std::string &name, int amount) -> bool;
-    auto increaseAttrib(const std::string &name, int amount) -> Attribute::attribute_t;
-
-    virtual auto increaseSkill(TYPE_OF_SKILL_ID skill, int amount) -> int;
-    virtual auto increaseMinorSkill(TYPE_OF_SKILL_ID skill, int amount) -> int;
-    virtual auto setSkill(TYPE_OF_SKILL_ID skill, int major, int minor) -> int;
-    virtual void deleteAllSkills();
-    virtual void learn(TYPE_OF_SKILL_ID skill, uint32_t actionPoints, uint8_t opponent);
-    virtual void teachMagic(unsigned char type, unsigned char flag);
-
-    auto isInRange(Character *cc, Coordinate distancemetric) const -> bool;
-    auto isInScreen(const position &pos) const -> bool;
-    virtual auto getScreenRange() const -> Coordinate;
-    auto distanceMetric(Character *cc) const -> Coordinate;
-    auto isInRangeToField(const position &m_pos, Coordinate distancemetric) const -> bool;
-    auto distanceMetricToPosition(const position &m_pos) const -> Coordinate;
-
-    virtual void talk(talk_type tt, const std::string &message);
-    virtual void talk(talk_type tt, const std::string &german, const std::string &english);
-
-    virtual void inform(const std::string &message, informType type = informServer) const;
-    virtual void inform(const std::string &german, const std::string &english, informType type = informServer) const;
-
-    virtual auto move(direction dir, bool active = true) -> bool;
-
-    virtual auto getNextStepDir(const position &goal, direction &dir) const -> bool;
-    auto getStepList(const position &goal, std::list<direction> &steps) const -> bool;
-
-    virtual auto Warp(const position &newPos) -> bool;
-    virtual auto forceWarp(const position &newPos) -> bool;
-
-    virtual void startMusic(short int title);
-    virtual void defaultMusic();
-
-    virtual void setQuestProgress(TYPE_OF_QUEST_ID questid, TYPE_OF_QUESTSTATUS progress);
-    virtual auto getQuestProgress(TYPE_OF_QUEST_ID questid, int &time) const -> TYPE_OF_QUESTSTATUS;
-
-    virtual void sendCharDescription(TYPE_OF_CHARACTER_ID id, const std::string &desc);
-
-    virtual auto isNewPlayer() const -> bool;
-    virtual auto pageGM(const std::string &ticket) -> bool;
-
-    virtual auto idleTime() const -> uint32_t;
-
-    virtual void sendBook(uint16_t bookID);
-
-    void updateAppearanceForAll(bool always);
-    virtual void forceUpdateAppearanceForAll();
-    void updateAppearanceForPlayer(Player *target, bool always);
-
-    virtual void performAnimation(uint8_t animID);
-
-    using SKILLMAP = std::map<TYPE_OF_SKILL_ID, skillvalue>;
-
-    auto GetMovement() const -> movement_type;
-    void SetMovement(movement_type tmovement);
-
-    void AddWeight();
-    void SubWeight();
-
-    inline virtual void setClippingActive(bool tclippingActive) {}
-    inline virtual auto getClippingActive() const -> bool { return true; }
-
-    SKILLMAP skills;
 
     /**
-     * array for the items of the character
-     * 0 = backpack, 1 to MAX_BODY_ITEMS - 1: equipped items
-     * MAX_BODY_ITEMS - 1 to MAX_BODY_ITEMS + MAX_BELT_SLOTS - 1: items in the belt
+     * @brief Counts items in specific inventory location
+     * @param where Location ("all", "belt", "body", "backpack")
+     * @param itemid Item ID to count
+     * @param data Optional script data to match (nullptr = any)
+     * @return Count in specified location
+     */
+    auto countItemAt(const std::string &where, TYPE_OF_ITEM_ID itemid,
+                     script_data_exchangemap const *data = nullptr) const -> int;
+
+    /**
+     * @brief Removes items from inventory
+     * @param itemid Item ID to remove
+     * @param count Number to remove
+     * @param data Optional script data to match
+     * @return Number that couldn't be removed (0 = all removed)
+     */
+    virtual auto eraseItem(TYPE_OF_ITEM_ID itemid, int count, script_data_exchangemap const *data = nullptr) -> int;
+
+    /**
+     * @brief Creates new items in inventory
+     * @param id Item ID
+     * @param number Quantity to create
+     * @param quality Item quality
+     * @param data Script data for items
+     * @return Number that couldn't be created (0 = all created)
+     */
+    virtual auto createItem(Item::id_type id, Item::number_type number, Item::quality_type quality,
+                            script_data_exchangemap const *data) -> int;
+
+    /**
+     * @brief Increases stack count at specific position
+     * @param pos Item position
+     * @param count Amount to increase
+     * @return Amount that couldn't be added
+     */
+    virtual auto increaseAtPos(unsigned char pos, int count) -> int;
+
+    /**
+     * @brief Creates items at specific position
+     * @param pos Item position
+     * @param newid Item ID
+     * @param count Quantity
+     * @return Amount that couldn't be created
+     */
+    virtual auto createAtPos(unsigned char pos, TYPE_OF_ITEM_ID newid, int count) -> int;
+
+    /**
+     * @brief Swaps item at position with new item
+     * @param pos Item position
+     * @param newid New item ID
+     * @param newQuality Quality for new item
+     * @return True if swap succeeded
+     */
+    virtual auto swapAtPos(unsigned char pos, TYPE_OF_ITEM_ID newid, int newQuality = 0) -> bool;
+
+    /**
+     * @brief Gets item at specific position as ScriptItem
+     * @param itempos Item position index
+     * @return ScriptItem wrapper for the item
+     */
+    virtual auto GetItemAt(unsigned char itempos) -> ScriptItem;
+
+    /**
+     * @brief Gets backpack container
+     * @return Pointer to backpack container (nullptr if none)
+     */
+    virtual auto GetBackPack() const -> Container *;
+
+    /**
+     * @brief Gets depot container by ID
+     * @param depotid Depot ID
+     * @return Pointer to depot container
+     */
+    auto GetDepot(uint32_t depotid) const -> Container *;
+
+    /**
+     * @brief Gets list of all items of specific type
+     * @param id Item ID to find
+     * @return Vector of ScriptItem wrappers
+     */
+    auto getItemList(TYPE_OF_ITEM_ID id) -> std::vector<ScriptItem>;
+
+    // Skill system
+    /**
+     * @brief Gets localized skill name
+     * @param s Skill ID
+     * @return Skill name string
+     */
+    virtual auto getSkillName(TYPE_OF_SKILL_ID s) const -> std::string;
+
+    /**
+     * @brief Gets major skill level
+     * @param s Skill ID
+     * @return Skill level (0-100)
+     */
+    virtual auto getSkill(TYPE_OF_SKILL_ID s) const -> unsigned short int;
+
+    /**
+     * @brief Gets complete skill value structure
+     * @param s Skill ID
+     * @return Pointer to skillvalue (nullptr if not learned)
+     */
+    virtual auto getSkillValue(TYPE_OF_SKILL_ID s) const -> const skillvalue *;
+
+    /**
+     * @brief Gets minor skill points (experience)
+     * @param s Skill ID
+     * @return Minor skill points
+     */
+    virtual auto getMinorSkill(TYPE_OF_SKILL_ID s) const -> unsigned short int;
+
+    // Appearance
+    /**
+     * @brief Sets skin color
+     * @param c Color value
+     */
+    void setSkinColour(const Colour &c);
+
+    /**
+     * @brief Gets skin color
+     * @return Skin color
+     */
+    auto getSkinColour() const -> Colour;
+
+    /**
+     * @brief Sets hair color
+     * @param c Color value
+     */
+    void setHairColour(const Colour &c);
+
+    /**
+     * @brief Gets hair color
+     * @return Hair color
+     */
+    auto getHairColour() const -> Colour;
+
+    /**
+     * @brief Sets hair style
+     * @param hairID Hair style ID
+     */
+    void setHair(uint8_t hairID);
+
+    /**
+     * @brief Gets hair style
+     * @return Hair style ID
+     */
+    auto getHair() const -> uint8_t;
+
+    /**
+     * @brief Sets beard style
+     * @param beardID Beard style ID
+     */
+    void setBeard(uint8_t beardID);
+
+    /**
+     * @brief Gets beard style
+     * @return Beard style ID
+     */
+    auto getBeard() const -> uint8_t;
+
+    /**
+     * @brief Gets complete appearance structure
+     * @return Appearance data
+     */
+    auto getAppearance() const -> appearance { return _appearance; }
+
+    // Attribute system
+    /**
+     * @brief Sets base attribute value with validation
+     * @param attribute Attribute to set
+     * @param value New base value
+     * @return True if value was valid and set
+     */
+    auto setBaseAttribute(Character::attributeIndex attribute, Attribute::attribute_t value) -> bool;
+
+    /**
+     * @brief Sets attribute value directly (includes offsets)
+     * @param attribute Attribute to set
+     * @param value New value
+     */
+    void setAttribute(Character::attributeIndex attribute, Attribute::attribute_t value);
+
+    /**
+     * @brief Gets base attribute value (without offsets)
+     * @param attribute Attribute to get
+     * @return Base attribute value
+     */
+    auto getBaseAttribute(Character::attributeIndex attribute) const -> Attribute::attribute_t;
+
+    /**
+     * @brief Gets total attribute value (base + offsets)
+     * @param attribute Attribute to get
+     * @return Total attribute value
+     */
+    auto getAttribute(Character::attributeIndex attribute) const -> Attribute::attribute_t;
+
+    /**
+     * @brief Increases base attribute with validation
+     * @param attribute Attribute to increase
+     * @param amount Amount to increase by
+     * @return True if increase was valid
+     */
+    auto increaseBaseAttribute(Character::attributeIndex attribute, int amount) -> bool;
+
+    /**
+     * @brief Increases attribute value (modifies offsets)
+     * @param attribute Attribute to increase
+     * @param amount Amount to increase
+     * @return New total value
+     */
+    auto increaseAttribute(Character::attributeIndex attribute, int amount) -> Attribute::attribute_t;
+
+    /**
+     * @brief Checks if base attribute value is valid for race
+     * @param attribute Attribute to check
+     * @param value Value to validate
+     * @return True if value is within race limits
+     */
+    auto isBaseAttributeValid(Character::attributeIndex attribute, Attribute::attribute_t value) const -> bool;
+
+    /**
+     * @brief Gets sum of all base attributes
+     * @return Total base attribute points
+     */
+    auto getBaseAttributeSum() const -> uint16_t;
+
+    /**
+     * @brief Gets maximum attribute points allowed for race
+     * @return Max attribute points
+     */
+    auto getMaxAttributePoints() const -> uint16_t;
+
+    /**
+     * @brief Saves base attributes to database (overridden by Player)
+     * @return True if saved successfully
+     */
+    virtual auto saveBaseAttributes() -> bool;
+
+    /**
+     * @brief Handles side effects of attribute changes
+     * @param attribute Attribute that changed
+     * @note Called automatically when attributes change
+     */
+    virtual void handleAttributeChange(Character::attributeIndex attribute);
+
+    // String-based attribute access (for Lua)
+    /**
+     * @brief Validates base attribute by name
+     * @param name Attribute name
+     * @param value Value to validate
+     * @return True if valid
+     */
+    auto isBaseAttribValid(const std::string &name, Attribute::attribute_t value) const -> bool;
+
+    /**
+     * @brief Sets base attribute by name
+     * @param name Attribute name
+     * @param value New value
+     * @return True if successful
+     */
+    auto setBaseAttrib(const std::string &name, Attribute::attribute_t value) -> bool;
+
+    /**
+     * @brief Sets attribute by name
+     * @param name Attribute name
+     * @param value New value
+     */
+    void setAttrib(const std::string &name, Attribute::attribute_t value);
+
+    /**
+     * @brief Gets base attribute by name
+     * @param name Attribute name
+     * @return Base value (0 if invalid name)
+     */
+    auto getBaseAttrib(const std::string &name) const -> Attribute::attribute_t;
+
+    /**
+     * @brief Increases base attribute by name
+     * @param name Attribute name
+     * @param amount Amount to increase
+     * @return True if successful
+     */
+    auto increaseBaseAttrib(const std::string &name, int amount) -> bool;
+
+    /**
+     * @brief Increases attribute by name
+     * @param name Attribute name
+     * @param amount Amount to increase
+     * @return New value (0 if invalid name)
+     */
+    auto increaseAttrib(const std::string &name, int amount) -> Attribute::attribute_t;
+
+    // Skill training
+    /**
+     * @brief Increases major skill level
+     * @param skill Skill ID
+     * @param amount Amount to increase
+     * @return New skill level
+     */
+    virtual auto increaseSkill(TYPE_OF_SKILL_ID skill, int amount) -> int;
+
+    /**
+     * @brief Increases minor skill points
+     * @param skill Skill ID
+     * @param amount Amount to increase
+     * @return New minor skill value
+     */
+    virtual auto increaseMinorSkill(TYPE_OF_SKILL_ID skill, int amount) -> int;
+
+    /**
+     * @brief Sets skill levels explicitly
+     * @param skill Skill ID
+     * @param major Major skill level
+     * @param minor Minor skill points
+     * @return New major skill level
+     */
+    virtual auto setSkill(TYPE_OF_SKILL_ID skill, int major, int minor) -> int;
+
+    /**
+     * @brief Removes all learned skills
+     */
+    virtual void deleteAllSkills();
+
+    /**
+     * @brief Processes skill learning from action
+     * @param skill Skill being trained
+     * @param actionPoints AP cost of action
+     * @param opponent Difficulty rating (0-255)
+     */
+    virtual void learn(TYPE_OF_SKILL_ID skill, uint32_t actionPoints, uint8_t opponent);
+
+    /**
+     * @brief Teaches magic spell to character
+     * @param type Magic school (0-3)
+     * @param flag Spell bit flag
+     */
+    virtual void teachMagic(unsigned char type, unsigned char flag);
+
+    // Distance and range checks
+    /**
+     * @brief Checks if another character is in range
+     * @param cc Target character
+     * @param distancemetric Maximum distance
+     * @return True if within range
+     */
+    auto isInRange(Character *cc, Coordinate distancemetric) const -> bool;
+
+    /**
+     * @brief Checks if position is within screen range
+     * @param pos Position to check
+     * @return True if visible on character's screen
+     */
+    auto isInScreen(const position &pos) const -> bool;
+
+    /**
+     * @brief Gets screen/view range distance
+     * @return View distance in tiles
+     */
+    virtual auto getScreenRange() const -> Coordinate;
+
+    /**
+     * @brief Calculates distance to another character
+     * @param cc Target character
+     * @return Distance value
+     */
+    auto distanceMetric(Character *cc) const -> Coordinate;
+
+    /**
+     * @brief Checks if field position is in range
+     * @param m_pos Field position
+     * @param distancemetric Maximum distance
+     * @return True if within range
+     */
+    auto isInRangeToField(const position &m_pos, Coordinate distancemetric) const -> bool;
+
+    /**
+     * @brief Calculates distance to position
+     * @param m_pos Target position
+     * @return Distance value
+     */
+    auto distanceMetricToPosition(const position &m_pos) const -> Coordinate;
+
+    // Communication
+    /**
+     * @brief Makes character speak
+     * @param tt Talk type (say, whisper, yell)
+     * @param message Message to speak
+     */
+    virtual void talk(talk_type tt, const std::string &message);
+
+    /**
+     * @brief Makes character speak with language-specific text
+     * @param tt Talk type
+     * @param german German text
+     * @param english English text
+     */
+    virtual void talk(talk_type tt, const std::string &german, const std::string &english);
+
+    /**
+     * @brief Sends informational message to character
+     * @param message Message text
+     * @param type Message priority/type
+     */
+    virtual void inform(const std::string &message, informType type = informServer) const;
+
+    /**
+     * @brief Sends language-specific informational message
+     * @param german German text
+     * @param english English text
+     * @param type Message priority/type
+     */
+    virtual void inform(const std::string &german, const std::string &english, informType type = informServer) const;
+
+    // Movement and positioning
+    /**
+     * @brief Moves character in direction
+     * @param dir Direction to move
+     * @param active True if active player movement
+     * @return True if move succeeded
+     */
+    virtual auto move(direction dir, bool active = true) -> bool;
+
+    /**
+     * @brief Gets next step direction toward goal
+     * @param goal Target position
+     * @param dir Output: direction to move
+     * @return True if path found
+     */
+    virtual auto getNextStepDir(const position &goal, direction &dir) const -> bool;
+
+    /**
+     * @brief Calculates full path to goal
+     * @param goal Target position
+     * @param steps Output: list of directions
+     * @return True if path found
+     */
+    auto getStepList(const position &goal, std::list<direction> &steps) const -> bool;
+
+    /**
+     * @brief Warps character to new position (checks validity)
+     * @param newPos Target position
+     * @return True if warp succeeded
+     */
+    virtual auto Warp(const position &newPos) -> bool;
+
+    /**
+     * @brief Forces warp regardless of validity
+     * @param newPos Target position
+     * @return True if warp succeeded
+     */
+    virtual auto forceWarp(const position &newPos) -> bool;
+
+    // Audio
+    /**
+     * @brief Starts music for character (Players only)
+     * @param title Music track ID
+     */
+    virtual void startMusic(short int title);
+
+    /**
+     * @brief Resets to default ambient music (Players only)
+     */
+    virtual void defaultMusic();
+
+    // Quest system
+    /**
+     * @brief Sets quest progress status
+     * @param questid Quest ID
+     * @param progress New progress value
+     */
+    virtual void setQuestProgress(TYPE_OF_QUEST_ID questid, TYPE_OF_QUESTSTATUS progress);
+
+    /**
+     * @brief Gets quest progress status
+     * @param questid Quest ID
+     * @param time Output: time since quest update
+     * @return Current quest status
+     */
+    virtual auto getQuestProgress(TYPE_OF_QUEST_ID questid, int &time) const -> TYPE_OF_QUESTSTATUS;
+
+    // Client-specific features (Players only)
+    /**
+     * @brief Sends character description text
+     * @param id Character ID being described
+     * @param desc Description text
+     */
+    virtual void sendCharDescription(TYPE_OF_CHARACTER_ID id, const std::string &desc);
+
+    /**
+     * @brief Checks if player is new (Players only)
+     * @return True if new player
+     */
+    virtual auto isNewPlayer() const -> bool;
+
+    /**
+     * @brief Sends GM page request (Players only)
+     * @param ticket Ticket message
+     * @return True if page sent
+     */
+    virtual auto pageGM(const std::string &ticket) -> bool;
+
+    /**
+     * @brief Gets idle time in seconds (Players only)
+     * @return Seconds idle
+     */
+    virtual auto idleTime() const -> uint32_t;
+
+    /**
+     * @brief Sends book content to player (Players only)
+     * @param bookID Book ID to display
+     */
+    virtual void sendBook(uint16_t bookID);
+
+    // Appearance updates
+    /**
+     * @brief Updates character appearance for all nearby players
+     * @param always True to force update even if unchanged
+     */
+    void updateAppearanceForAll(bool always);
+
+    /**
+     * @brief Forces appearance update for all players
+     */
+    virtual void forceUpdateAppearanceForAll();
+
+    /**
+     * @brief Updates appearance for specific player
+     * @param target Target player
+     * @param always True to force update
+     */
+    void updateAppearanceForPlayer(Player *target, bool always);
+
+    /**
+     * @brief Performs animation
+     * @param animID Animation ID
+     */
+    virtual void performAnimation(uint8_t animID);
+
+    /**
+     * @brief Skill ID to skill value mapping
+     */
+    using SKILLMAP = std::map<TYPE_OF_SKILL_ID, skillvalue>;
+
+    /**
+     * @brief Gets character movement type
+     * @return Movement type (walk, run, crawl, etc.)
+     */
+    auto GetMovement() const -> movement_type;
+
+    /**
+     * @brief Sets character movement type
+     * @param tmovement New movement type
+     */
+    void SetMovement(movement_type tmovement);
+
+    /**
+     * @brief Recalculates and adds inventory weight
+     */
+    void AddWeight();
+
+    /**
+     * @brief Recalculates and subtracts inventory weight
+     */
+    void SubWeight();
+
+    /**
+     * @brief Sets whether clipping is active (Players only)
+     * @param tclippingActive True to enable clipping
+     */
+    inline virtual void setClippingActive(bool tclippingActive) {}
+
+    /**
+     * @brief Gets clipping state (Players only)
+     * @return True if clipping enabled
+     */
+    inline virtual auto getClippingActive() const -> bool { return true; }
+
+    SKILLMAP skills; ///< Map of learned skills
+
+    /**
+     * @brief Character inventory array
+     * 
+     * Layout:
+     * - Index 0: backpack
+     * - Indices 1 to MAX_BODY_ITEMS-1: equipped items (armor, weapons, etc.)
+     * - Indices MAX_BODY_ITEMS to MAX_BODY_ITEMS+MAX_BELT_SLOTS-1: belt items
      */
     std::array<Item, MAX_BODY_ITEMS + MAX_BELT_SLOTS> items = {};
 
-    Container *backPackContents{nullptr};
+    Container *backPackContents{nullptr}; ///< Container holding backpack items
 
     /**
-     * map to the different depots
-     * first param is the depot id
-     * second param is the pointer to the container which stores the items in this depot
+     * @brief Map of depot containers
+     * 
+     * Key: depot ID
+     * Value: pointer to container storing depot items
      */
     std::map<uint32_t, Container *> depotContents;
 
+    /**
+     * @brief Ages all inventory items (durability decay)
+     */
     virtual void ageInventory();
 
+    /**
+     * @brief Checks if character is alive
+     * @return True if alive (hitpoints > 0)
+     */
     inline auto isAlive() const -> bool { return alive; }
 
+    /**
+     * @brief Sets alive state
+     * @param t True if alive
+     */
     virtual void setAlive(bool t);
 
-    character_type enemytype = player;
-    TYPE_OF_CHARACTER_ID enemyid = 0;
+    // Combat system
+    character_type enemytype = player; ///< Type of current enemy
+    TYPE_OF_CHARACTER_ID enemyid = 0;  ///< ID of current enemy
+
+    /**
+     * @brief Initiates attack on target
+     * @param target Character to attack
+     * @return True if attack started
+     */
     virtual auto attack(Character *target) -> bool;
+
+    /**
+     * @brief Stops current attack
+     */
     virtual void stopAttack();
+
+    /**
+     * @brief Gets current attack target
+     * @return Smart pointer to target (nullptr if none)
+     */
     auto getAttackTarget() const -> character_ptr;
 
+    // Weight and carrying capacity
+    /**
+     * @brief Calculates maximum carrying weight
+     * @return Max weight in unit (based on strength)
+     */
     auto maxLoadWeight() const -> unsigned short int;
+
+    /**
+     * @brief Calculates current inventory weight
+     * @return Current weight
+     */
     auto LoadWeight() const -> int;
+
+    /**
+     * @brief Calculates relative load (current/max)
+     * @return Load ratio (0.0 to 1.0+)
+     */
     auto relativeLoad() const -> double;
 
+    /**
+     * @brief Load burden level affecting movement
+     */
     enum class LoadLevel { unburdened, burdened, overtaxed };
 
+    /**
+     * @brief Gets current load burden level
+     * @return Load level enum
+     */
     auto loadFactor() const -> LoadLevel;
 
     /**
-     * returns the weight of a container
-     * @param id of the container from which we want to get the weight
-     * @param count if the weight should be positive or negative
-     * @param tcont the container from which we want to get the weight
-     * @return the +/- weight of the container
+     * @brief Calculates weight of a container
+     * @param id Item ID of container
+     * @param count Stack count (positive or negative)
+     * @param tcont Pointer to container data
+     * @return Total weight (positive or negative)
      */
     static auto weightContainer(unsigned short int id, int count, Container *tcont) -> int;
 
     /**
-     * checks if in tcont is enough place for count items with id
-     * @param id the item which should be placed in the container
-     * @param count how much items should be added to the container
-     * @param tcont pointer to the container (items inside the container)
-     * @return true if count items of id can be added otherwise false
+     * @brief Checks if adding items won't exceed weight limit
+     * @param id Item ID to add
+     * @param count Number to add
+     * @param tcont Container to add to
+     * @return True if weight would be acceptable
      */
     auto weightOK(TYPE_OF_ITEM_ID id, int count, Container *tcont) const -> bool;
 
+    /**
+     * @brief Turns character to face direction
+     * @param dir Direction to face
+     */
     virtual void turn(direction dir);
+
+    /**
+     * @brief Turns character to face position
+     * @param posi Position to face toward
+     */
     virtual void turn(const position &posi);
 
+    /**
+     * @brief Receives text from another character
+     * @param tt Talk type
+     * @param message Message text
+     * @param cc Speaking character
+     */
     virtual void receiveText(talk_type tt, const std::string &message, Character *cc);
 
+    /**
+     * @brief Introduces a player to this character (overridden by Player)
+     * @param player Player being introduced
+     */
     virtual void introducePlayer(Player *player);
 
+    /**
+     * @brief Calls attack script handlers
+     * @param Attacker Attacking character
+     * @param Defender Defending character
+     */
     void callAttackScript(Character *Attacker, Character *Defender);
 
+    // Dialog system
+    /**
+     * @brief Requests text input from player
+     * @param inputDialog Input dialog to display
+     */
     virtual void requestInputDialog(InputDialog *inputDialog);
+
+    /**
+     * @brief Requests message display
+     * @param messageDialog Message dialog to display
+     */
     virtual void requestMessageDialog(MessageDialog *messageDialog);
+
+    /**
+     * @brief Requests merchant trade dialog
+     * @param merchantDialog Merchant dialog to display
+     */
     virtual void requestMerchantDialog(MerchantDialog *merchantDialog);
+
+    /**
+     * @brief Requests selection dialog
+     * @param selectionDialog Selection dialog to display
+     */
     virtual void requestSelectionDialog(SelectionDialog *selectionDialog);
+
+    /**
+     * @brief Requests crafting dialog
+     * @param craftingDialog Crafting dialog to display
+     */
     virtual void requestCraftingDialog(CraftingDialog *craftingDialog);
+
+    /**
+     * @brief Requests look-at for crafting result
+     * @param dialogId Dialog ID
+     * @param lookAt Look-at data to populate
+     */
     virtual void requestCraftingLookAt(unsigned int dialogId, ItemLookAt &lookAt);
+
+    /**
+     * @brief Requests look-at for crafting ingredient
+     * @param dialogId Dialog ID
+     * @param lookAt Look-at data to populate
+     */
     virtual void requestCraftingLookAtIngredient(unsigned int dialogId, ItemLookAt &lookAt);
 
+    /**
+     * @brief Logs admin action (Players only)
+     * @param message Log message
+     */
     virtual void logAdmin(const std::string &message);
 
+    /**
+     * @brief Gets monster loot table (Monsters only)
+     * @return Reference to loot structure
+     * @throws NoLootFound if no loot available
+     */
     virtual auto getLoot() const -> const MonsterStruct::loottype &;
 
 protected:
+    /**
+     * @brief Race definition structure with attribute limits
+     * 
+     * Contains min/max values for all attributes based on race.
+     */
     struct RaceStruct {
-        std::string racename;
-        unsigned short int points;
-        unsigned short int minage;
-        unsigned short int maxage;
-        unsigned short int minweight;
-        unsigned short int maxweight;
-        unsigned char minbodyheight;
-        unsigned char maxbodyheight;
-        unsigned char minagility;
-        unsigned char maxagility;
-        unsigned char minconstitution;
-        unsigned char maxconstitution;
-        unsigned char mindexterity;
-        unsigned char maxdexterity;
-        unsigned char minessence;
-        unsigned char maxessence;
-        unsigned char minintelligence;
-        unsigned char maxintelligence;
-        unsigned char minperception;
-        unsigned char maxperception;
-        unsigned char minstrength;
-        unsigned char maxstrength;
-        unsigned char minwillpower;
-        unsigned char maxwillpower;
+        std::string racename;       ///< Race name
+        unsigned short int points;  ///< Starting attribute points
+        unsigned short int minage;  ///< Minimum age
+        unsigned short int maxage;  ///< Maximum age
+        unsigned short int minweight;  ///< Minimum weight
+        unsigned short int maxweight;  ///< Maximum weight
+        unsigned char minbodyheight;   ///< Minimum body height
+        unsigned char maxbodyheight;   ///< Maximum body height
+        unsigned char minagility;      ///< Minimum agility
+        unsigned char maxagility;      ///< Maximum agility
+        unsigned char minconstitution; ///< Minimum constitution
+        unsigned char maxconstitution; ///< Maximum constitution
+        unsigned char mindexterity;    ///< Minimum dexterity
+        unsigned char maxdexterity;    ///< Maximum dexterity
+        unsigned char minessence;      ///< Minimum essence
+        unsigned char maxessence;      ///< Maximum essence
+        unsigned char minintelligence; ///< Minimum intelligence
+        unsigned char maxintelligence; ///< Maximum intelligence
+        unsigned char minperception;   ///< Minimum perception
+        unsigned char maxperception;   ///< Maximum perception
+        unsigned char minstrength;     ///< Minimum strength
+        unsigned char maxstrength;     ///< Maximum strength
+        unsigned char minwillpower;    ///< Minimum willpower
+        unsigned char maxwillpower;    ///< Maximum willpower
     };
 
+    /**
+     * @brief Sets character ID
+     * @param id New character ID
+     */
     void setId(TYPE_OF_CHARACTER_ID id);
+
+    /**
+     * @brief Sets character name
+     * @param name New name
+     */
     void setName(const std::string &name);
+
+    /**
+     * @brief Sets position directly
+     * @param pos New position
+     */
     void setPosition(const position &pos);
+
+    /**
+     * @brief Sets race directly
+     * @param race New race ID
+     */
     void setRace(TYPE_OF_RACE_ID race);
+
+    /**
+     * @brief Sets facing direction directly
+     * @param faceTo New direction
+     */
     void setFaceTo(face_to faceTo);
+
+    /**
+     * @brief Sets magic flags for school
+     * @param type Magic school
+     * @param flags New spell bitflags
+     */
     void setMagicFlags(magic_type type, uint64_t flags);
 
-    bool _is_on_route = false;
-    int poisonvalue = 0;
-    int mental_capacity = 0;
-    World *_world;
+    bool _is_on_route = false;      ///< True if following automatic route
+    int poisonvalue = 0;            ///< Current poison damage level
+    int mental_capacity = 0;        ///< Mental capacity for effects
+    World *_world;                  ///< Pointer to game world
 
+    /**
+     * @brief Checks if character can move to field
+     * @param field Target field
+     * @return True if movement allowed
+     */
     virtual auto moveToPossible(const map::Field &field) const -> bool;
 
-    // returns time of a move in ms
+    /**
+     * @brief Calculates time cost of movement
+     * @param targetField Destination field
+     * @param diagonalMove True if diagonal movement
+     * @param running True if running
+     * @return Move time in milliseconds
+     */
     virtual auto getMoveTime(const map::Field &targetField, bool diagonalMove, bool running) const
             -> TYPE_OF_WALKINGCOST;
 
+    /**
+     * @brief Checks if character can speak (has enough AP)
+     * @param tt Talk type
+     * @return True if can afford speech
+     */
     auto canTalk(talk_type tt) const -> bool;
+
+    /**
+     * @brief Gets AP cost of speech type
+     * @param tt Talk type
+     * @return Action point cost
+     */
     static /*consteval*/ auto talkCost(talk_type tt) -> int;
+
+    /**
+     * @brief Logs speech to server log
+     * @param tt Talk type
+     * @param message Message text
+     */
     void logTalk(talk_type tt, const std::string &message) const;
+
+    /**
+     * @brief Processes speech through scripts
+     * @param tt Talk type
+     * @param message Original message
+     * @return Processed message
+     */
     auto talkScript(talk_type tt, const std::string &message) -> std::string;
 
-    appearance _appearance;
+    appearance _appearance; ///< Character visual appearance
 
 private:
-    TYPE_OF_CHARACTER_ID id = 0;
-    std::string name;
-    movement_type _movement = movement_type::walk;
-    std::vector<Attribute> attributes;
-    bool alive = true;
-    int actionPoints = NP_MAX_AP;
-    int fightPoints = NP_MAX_FP;
-    short int activeLanguage = 0;
-    position pos = {0, 0, 0};
-    bool attackmode = false;
-    std::string lastSpokenText = {};
-    bool isinvisible = false;
-    TYPE_OF_RACE_ID race = 0;
-    face_to faceto = north;
-    s_magic magic{};
-    double speed = 1.0;
+    TYPE_OF_CHARACTER_ID id = 0;       ///< Unique character identifier
+    std::string name;                  ///< Character name
+    movement_type _movement = movement_type::walk; ///< Current movement mode
+    std::vector<Attribute> attributes; ///< All character attributes
+    bool alive = true;                 ///< Alive state (hitpoints > 0)
+    int actionPoints = NP_MAX_AP;      ///< Current action points
+    int fightPoints = NP_MAX_FP;       ///< Current fight points
+    short int activeLanguage = 0;      ///< Active speech language
+    position pos = {0, 0, 0};          ///< Current world position
+    bool attackmode = false;           ///< True if in combat mode
+    std::string lastSpokenText = {};   ///< Last message spoken
+    bool isinvisible = false;          ///< Invisibility state
+    TYPE_OF_RACE_ID race = 0;          ///< Character race ID
+    face_to faceto = north;            ///< Current facing direction
+    s_magic magic{};                   ///< Magic school and spell data
+    double speed = 1.0;                ///< Movement speed multiplier
 };
 
+/**
+ * @brief Stream output operator for Character
+ * @param os Output stream
+ * @param character Character to output
+ * @return Modified stream
+ */
 auto operator<<(std::ostream &os, const Character &character) -> std::ostream &;
 
 #endif

--- a/src/CharacterContainer.hpp
+++ b/src/CharacterContainer.hpp
@@ -28,6 +28,14 @@
 #include <unordered_map>
 #include <vector>
 
+/**
+ * @brief Template container providing spatial indexing for character lookup.
+ * 
+ * Efficiently stores and retrieves characters by ID, name, position, or range.
+ * Maintains both direct ID lookup and spatial index for area queries.
+ * 
+ * @tparam T Character type (Player, Monster, or NPC)
+ */
 template <class T> class CharacterContainer {
 public:
     using pointer = T *;

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -24,12 +24,33 @@
 #include <string>
 #include <utility>
 
+/**
+ * @brief Base class for configuration entries that can be loaded from config files.
+ *
+ * This abstract base class provides the interface for reading and writing configuration
+ * values from/to streams. Configuration entries are registered globally and populated
+ * when a config file is loaded.
+ */
 class ConfigEntryBase {
 public:
+    /**
+     * @brief Constructs a config entry with a given name.
+     * @param config_name The name of the configuration key in the config file.
+     */
     explicit ConfigEntryBase(const std::string &config_name);
 
     friend auto operator>>(std::istream &is, ConfigEntryBase & /*config_entry*/) -> std::istream &;
+
+    /**
+     * @brief Reads the configuration value from an input stream.
+     * @param is The input stream to read from.
+     */
     virtual void read(std::istream &is) = 0;
+
+    /**
+     * @brief Writes the configuration value to an output stream.
+     * @param os The output stream to write to.
+     */
     virtual void write(std::ostream &os) const = 0;
 
     ConfigEntryBase(const ConfigEntryBase &) = default;
@@ -38,40 +59,108 @@ public:
     auto operator=(ConfigEntryBase &&) -> ConfigEntryBase & = default;
     virtual ~ConfigEntryBase() = default;
 
+    /**
+     * @brief Checks if this configuration entry has been initialized from a config file.
+     * @return true if the entry was loaded from a config file, false if using default value.
+     */
     [[nodiscard]] auto isInitialized() const -> bool { return _initialized; }
 
 protected:
-    std::string _config_name;
-    bool _initialized = {false};
+    std::string _config_name;    ///< The configuration key name.
+    bool _initialized = {false}; ///< Whether this entry was loaded from a config file.
 };
 
+/**
+ * @brief Stream input operator for reading config entries.
+ * @param is The input stream.
+ * @param config_entry The config entry to read into.
+ * @return The input stream.
+ */
 auto operator>>(std::istream &is, ConfigEntryBase &config_entry) -> std::istream &;
+
+/**
+ * @brief Stream output operator for writing config entries.
+ * @param os The output stream.
+ * @param config_entry The config entry to write.
+ * @return The output stream.
+ */
 auto operator<<(std::ostream &os, const ConfigEntryBase &config_entry) -> std::ostream &;
 
+/**
+ * @brief Templated configuration entry that holds a specific value type.
+ * @tparam T The type of value this configuration entry holds.
+ *
+ * This class provides type-safe configuration storage with default values and
+ * automatic conversion to the underlying type.
+ */
 template <typename T> class ConfigEntry : public ConfigEntryBase {
 public:
+    /**
+     * @brief Constructs a configuration entry with a name and optional default value.
+     * @param config_name The configuration key name.
+     * @param default_value The default value if not specified in the config file.
+     */
     explicit ConfigEntry(const std::string &config_name, T default_value = {})
             : ConfigEntryBase{config_name}, _item{std::move(default_value)} {}
 
+    /**
+     * @brief Implicit conversion to the underlying type.
+     * @return The configuration value.
+     */
     operator T() const { return _item; }
 
+    /**
+     * @brief Function call operator to retrieve the value.
+     * @return The configuration value.
+     */
     auto operator()() const -> T { return _item; }
 
+    /**
+     * @brief Reads the value from a stream.
+     * @param is The input stream to read from.
+     */
     void read(std::istream &is) override {
         is >> _item;
         _initialized = true;
     }
+
+    /**
+     * @brief Writes the value to a stream.
+     * @param os The output stream to write to.
+     */
     void write(std::ostream &os) const override { os << _item; }
 
 private:
-    T _item;
+    T _item; ///< The stored configuration value.
 };
 
+/**
+ * @brief Singleton class managing all server configuration settings.
+ *
+ * This class holds all configuration entries for the server, including paths,
+ * database settings, network ports, and game parameters. Configuration is loaded
+ * from a file using the load() method.
+ */
 class Config {
 public:
+    /**
+     * @brief Loads configuration from a file.
+     * @param config_file Path to the configuration file.
+     * @return true if the file was loaded successfully, false otherwise.
+     */
     static auto load(const std::string &config_file) -> bool;
+
+    /**
+     * @brief Registers a configuration entry for automatic population.
+     * @param config_name The configuration key name.
+     * @param entry Pointer to the configuration entry to register.
+     */
     static void register_entry(const std::string &config_name, ConfigEntryBase *entry);
 
+    /**
+     * @brief Gets the singleton instance of the Config.
+     * @return Reference to the Config instance.
+     */
     static auto instance() -> Config & {
         if (!_instance) {
             _instance = std::make_unique<Config>();
@@ -80,28 +169,28 @@ public:
         return *_instance;
     }
 
-    const ConfigEntry<std::string> datadir{"datadir", "./data/"};
-    const ConfigEntry<std::string> scriptdir{"scriptdir", "./script/"};
+    const ConfigEntry<std::string> datadir{"datadir", "./data/"};       ///< Path to data directory.
+    const ConfigEntry<std::string> scriptdir{"scriptdir", "./script/"}; ///< Path to script directory.
 
-    const ConfigEntry<uint16_t> port{"port", 3012};
+    const ConfigEntry<uint16_t> port{"port", 3012}; ///< Server listening port.
 
-    const ConfigEntry<std::string> postgres_db{"postgres_db", "illarion"};
-    const ConfigEntry<std::string> postgres_user{"postgres_user", "illarion"};
-    const ConfigEntry<std::string> postgres_pwd{"postgres_pwd", "illarion"};
-    const ConfigEntry<std::string> postgres_host{"postgres_host", "/var/run/postgresql"};
-    const ConfigEntry<uint16_t> postgres_port{"postgres_port", 5432};
-    const ConfigEntry<std::string> postgres_schema_server{"postgres_schema_server", "server"};
-    const ConfigEntry<std::string> postgres_schema_account{"postgres_schema_account", "accounts"};
+    const ConfigEntry<std::string> postgres_db{"postgres_db", "illarion"};                ///< PostgreSQL database name.
+    const ConfigEntry<std::string> postgres_user{"postgres_user", "illarion"};            ///< PostgreSQL username.
+    const ConfigEntry<std::string> postgres_pwd{"postgres_pwd", "illarion"};              ///< PostgreSQL password.
+    const ConfigEntry<std::string> postgres_host{"postgres_host", "/var/run/postgresql"}; ///< PostgreSQL host.
+    const ConfigEntry<uint16_t> postgres_port{"postgres_port", 5432};                     ///< PostgreSQL port.
+    const ConfigEntry<std::string> postgres_schema_server{"postgres_schema_server", "server"};     ///< Server schema.
+    const ConfigEntry<std::string> postgres_schema_account{"postgres_schema_account", "accounts"}; ///< Account schema.
 
-    const ConfigEntry<int16_t> debug{"debug", 0};
+    const ConfigEntry<int16_t> debug{"debug", 0}; ///< Debug level.
 
-    const ConfigEntry<uint16_t> clientversion{"clientversion", 122};
-    const ConfigEntry<int16_t> playerstart_x{"playerstart_x", 0};
-    const ConfigEntry<int16_t> playerstart_y{"playerstart_y", 0};
-    const ConfigEntry<int16_t> playerstart_z{"playerstart_z", 0};
+    const ConfigEntry<uint16_t> clientversion{"clientversion", 122}; ///< Required client version.
+    const ConfigEntry<int16_t> playerstart_x{"playerstart_x", 0};    ///< Default player start X coordinate.
+    const ConfigEntry<int16_t> playerstart_y{"playerstart_y", 0};    ///< Default player start Y coordinate.
+    const ConfigEntry<int16_t> playerstart_z{"playerstart_z", 0};    ///< Default player start Z coordinate.
 
 private:
-    static std::unique_ptr<Config> _instance;
+    static std::unique_ptr<Config> _instance; ///< Singleton instance.
 };
 
 #endif

--- a/src/Container.hpp
+++ b/src/Container.hpp
@@ -28,64 +28,302 @@
 
 class ItemTable;
 
+/**
+ * @brief Exception thrown when container operations exceed maximum recursion depth.
+ * 
+ * Prevents infinite loops when processing nested containers.
+ */
 class RecursionException : public std::exception {};
 
+/**
+ * @brief Represents a container that can hold items and nested containers.
+ * 
+ * Container manages a collection of items stored in numbered slots, with support for:
+ * - Item stacking and automatic merging
+ * - Nested containers (bags within bags)
+ * - Weight calculation including contents
+ * - Item aging and wear management
+ * - Serialization to/from file streams
+ * - Depot functionality for persistent player storage
+ * 
+ * Containers are non-copyable and non-movable. They maintain two maps:
+ * - items: Maps slot numbers to Item objects
+ * - containers: Maps slot numbers to nested Container pointers (for container items)
+ * 
+ * Slot capacity is determined by the container's item type definition in ContainerObjectTable.
+ * 
+ * @see Item
+ * @see ContainerObjectTable
+ * @note Container owns and manages the lifetime of nested Container pointers
+ */
 class Container {
 public:
-    using ITEMMAP = std::map<TYPE_OF_CONTAINERSLOTS, Item>;
-    using CONTAINERMAP = std::map<TYPE_OF_CONTAINERSLOTS, Container *>;
+    using ITEMMAP = std::map<TYPE_OF_CONTAINERSLOTS, Item>; ///< Map of slot positions to items
+    using CONTAINERMAP = std::map<TYPE_OF_CONTAINERSLOTS, Container *>; ///< Map of slot positions to nested containers
 
+    /**
+     * @brief Creates a new container of the specified type.
+     * 
+     * @param itemId The container item type ID from ContainerObjectTable
+     */
     explicit Container(Item::id_type itemId);
+    
     Container(const Container &) = delete;
     Container(Container &&) = delete;
     auto operator=(const Container &) -> Container & = delete;
     auto operator=(Container &&) -> Container & = delete;
+    
+    /**
+     * @brief Destructor that cleans up all items and nested containers.
+     */
     virtual ~Container();
 
+    /**
+     * @brief Removes an item or portion of a stack from a specific slot.
+     * 
+     * If the item is a container, also retrieves the nested Container pointer.
+     * For stackable items, can take a partial count.
+     * 
+     * @param nr Slot number to take from
+     * @param item Output parameter receiving the removed item
+     * @param cc Output parameter receiving nested container pointer (nullptr if not a container)
+     * @param count Number of items to take from stack (entire stack if >= current number)
+     * @return true if item was successfully taken
+     */
     auto TakeItemNr(TYPE_OF_CONTAINERSLOTS nr, Item &item, Container *&cc, Item::number_type count) -> bool;
+    
+    /**
+     * @brief Views an item at a specific slot without removing it.
+     * 
+     * @param nr Slot number to view
+     * @param item Output ScriptItem with item data and location context
+     * @param cc Output parameter receiving nested container pointer if applicable
+     * @return true if item exists at that slot
+     */
     auto viewItemNr(TYPE_OF_CONTAINERSLOTS nr, ScriptItem &item, Container *&cc) -> bool;
+    
+    /**
+     * @brief Modifies the durability of an item at a specific slot.
+     * 
+     * @param nr Slot number
+     * @param amount Durability change (positive to repair, negative to damage)
+     * @return true if item exists and quality was changed
+     */
     auto changeQualityAt(TYPE_OF_CONTAINERSLOTS nr, short int amount) -> bool;
+    
+    /**
+     * @brief Inserts a container with its contents into the first available slot.
+     * 
+     * @param item The container item
+     * @param cc Pointer to the Container object to insert
+     * @return true if successfully inserted
+     */
     auto InsertContainer(const Item &item, Container *cc) -> bool;
+    
+    /**
+     * @brief Inserts a container with its contents at a specific slot.
+     * 
+     * @param item The container item
+     * @param cc Pointer to the Container object to insert
+     * @param pos Target slot position
+     * @return true if successfully inserted
+     */
     auto InsertContainer(const Item &item, Container *cc, TYPE_OF_CONTAINERSLOTS pos) -> bool;
+    
+    /**
+     * @brief Attempts to merge a stackable item with existing stacks.
+     * 
+     * Finds matching items (same ID and data) and adds to their stacks up to MaxStack limit.
+     * 
+     * @param item Item to merge
+     * @return Number of items that couldn't be merged (0 if fully merged)
+     */
     auto mergeItem(Item item) -> Item::number_type;
+    
+    /**
+     * @brief Inserts an item with automatic stacking/merging.
+     * 
+     * @param item Item to insert
+     * @param merge If true, attempts to merge with existing stacks first
+     * @return true if item was fully inserted
+     */
     auto InsertItem(Item item, bool merge) -> bool;
+    
+    /**
+     * @brief Inserts an item at a specific slot, stacking if possible.
+     * 
+     * @param item Item to insert
+     * @param pos Target slot position
+     * @return true if successfully inserted
+     */
     auto InsertItem(Item item, TYPE_OF_CONTAINERSLOTS /*pos*/) -> bool;
+    
+    /**
+     * @brief Inserts an item with automatic merging enabled.
+     * 
+     * @param item Item to insert
+     * @return true if item was fully inserted
+     */
     auto InsertItem(const Item &item) -> bool;
 
+    /**
+     * @brief Serializes container and contents to binary stream.
+     * 
+     * @param where Output file stream
+     */
     void Save(std::ofstream &where) const;
+    
+    /**
+     * @brief Deserializes container and contents from binary stream.
+     * 
+     * @param where Input file stream
+     */
     void Load(std::ifstream &where);
 
+    /**
+     * @brief Ages all items, reducing wear by one.
+     * 
+     * Items with wear reaching 0 are destroyed. Recursively ages nested containers.
+     * 
+     * @param inventory If true, only ages items marked as rotting in inventory
+     */
     void doAge(bool inventory = false);
+    
+    /**
+     * @brief Resets wear on all items that don't rot in inventory.
+     * 
+     * Sets wear to the item's AgeingSpeed for applicable items.
+     */
     void resetWear();
 
+    /**
+     * @brief Counts items of a specific type, optionally matching custom data.
+     * 
+     * Recursively searches nested containers.
+     * 
+     * @param itemid Item type ID to count
+     * @param data Optional custom data that items must match (nullptr = ignore data)
+     * @return Total count of matching items
+     */
     virtual auto countItem(Item::id_type itemid, script_data_exchangemap const *data = nullptr) const -> int;
 
-    // TODO merge implementations of both addContentToList variations
+    /**
+     * @brief Adds items of a specific type to a list.
+     * 
+     * Recursively searches nested containers, creating ScriptItem entries with location context.
+     * 
+     * @param itemid Item type ID to find
+     * @param list Output vector to append ScriptItems to
+     */
     void addContentToList(Item::id_type itemid, std::vector<ScriptItem> &list);
+    
+    /**
+     * @brief Adds all items to a list.
+     * 
+     * Recursively searches nested containers.
+     * 
+     * @param list Output vector to append ScriptItems to
+     */
     void addContentToList(std::vector<ScriptItem> &list);
 
+    /**
+     * @brief Gets all items of a specific type as a list.
+     * 
+     * @param itemid Item type ID to find
+     * @return Vector of ScriptItems matching the type
+     */
     auto getItemList(Item::id_type itemid) -> std::vector<ScriptItem>;
+    
+    /**
+     * @brief Gets all items as a list.
+     * 
+     * @return Vector of all ScriptItems in this container and nested containers
+     */
     auto getItemList() -> std::vector<ScriptItem>;
 
+    /**
+     * @brief Removes a specific count of items, optionally matching custom data.
+     * 
+     * Recursively searches nested containers. Removes from stacks as needed.
+     * 
+     * @param itemid Item type ID to remove
+     * @param count Number of items to remove
+     * @param data Optional custom data that items must match (nullptr = ignore data)
+     * @return Number of items actually removed
+     */
     virtual auto eraseItem(Item::id_type itemid, Item::number_type count, script_data_exchangemap const *data = nullptr)
             -> int;
 
+    /**
+     * @brief Increases the stack count of an item at a specific position.
+     * 
+     * @param pos Slot position
+     * @param count Number to add to stack (capped at MaxStack)
+     * @return New stack count
+     */
     auto increaseAtPos(unsigned char pos, int count) -> int;
 
+    /**
+     * @brief Replaces the item at a position with a different item type.
+     * 
+     * @param pos Slot position
+     * @param newid New item type ID
+     * @param newQuality New quality value (0 to keep existing quality)
+     * @return true if item was successfully swapped
+     */
     auto swapAtPos(unsigned char pos, Item::id_type newid, Item::quality_type newQuality = 0) -> bool;
 
+    /**
+     * @brief Updates an item in the container based on ScriptItem changes.
+     * 
+     * @param item ScriptItem with updated properties
+     * @return true if item was found and updated
+     */
     auto changeItem(ScriptItem &item) -> bool;
 
+    /**
+     * @brief Calculates total weight of container and all contents.
+     * 
+     * Recursively includes weight of nested containers and their contents.
+     * 
+     * @return Total weight in game units
+     */
     auto weight() -> int;
 
+    /**
+     * @brief Gets the maximum number of slots this container can hold.
+     * 
+     * @return Slot count from ContainerObjectTable
+     */
     [[nodiscard]] virtual auto getSlotCount() const -> TYPE_OF_CONTAINERSLOTS;
 
+    /**
+     * @brief Gets the items map.
+     * 
+     * @return Const reference to slot->Item map
+     */
     [[nodiscard]] inline auto getItems() const -> const ITEMMAP & { return items; }
+    
+    /**
+     * @brief Gets the nested containers map.
+     * 
+     * @return Const reference to slot->Container* map
+     */
     [[nodiscard]] inline auto getContainers() const -> const CONTAINERMAP & { return containers; }
 
+    /**
+     * @brief Finds the first available empty slot.
+     * 
+     * @return Slot number of first free slot, or getSlotCount() if full
+     */
     [[nodiscard]] auto getFirstFreeSlot() const -> TYPE_OF_CONTAINERSLOTS;
 
 
+    /**
+     * @brief Checks if this container is a depot chest.
+     * 
+     * @return true if itemId matches any of the DEPOTITEMS constants
+     */
     [[nodiscard]] inline auto isDepot() const -> bool {
 
         for (const auto& DEPOTITEM : DEPOTITEMS) {
@@ -97,15 +335,35 @@ public:
     }
 
 private:
-    static constexpr auto maximumRecursionDepth = 100;
+    static constexpr auto maximumRecursionDepth = 100; ///< Maximum nesting depth to prevent infinite recursion
 
+    /**
+     * @brief Inserts an item into the first available slot.
+     * 
+     * @param item Item to insert
+     */
     void insertIntoFirstFreeSlot(Item &item);
+    
+    /**
+     * @brief Inserts a container into the first available slot.
+     * 
+     * @param item Container item
+     * @param container Container pointer
+     */
     void insertIntoFirstFreeSlot(Item &item, Container *container);
+    
+    /**
+     * @brief Calculates weight recursively with depth tracking.
+     * 
+     * @param rekt Current recursion depth
+     * @return Total weight
+     * @throws RecursionException if maximumRecursionDepth exceeded
+     */
     auto recursiveWeight(int rekt) -> int;
 
-    Item::id_type itemId{};
-    ITEMMAP items;
-    CONTAINERMAP containers;
+    Item::id_type itemId{}; ///< The item type ID of this container
+    ITEMMAP items; ///< Map of slot positions to items
+    CONTAINERMAP containers; ///< Map of slot positions to nested containers
 };
 
 #endif

--- a/src/InitialConnection.hpp
+++ b/src/InitialConnection.hpp
@@ -26,6 +26,12 @@
 
 class NetInterface;
 
+/**
+ * @brief Handles initial client connections before player authentication.
+ * 
+ * Accepts incoming TCP connections on the game port and queues them for
+ * the PlayerManager to process, authenticate, and convert into Player objects.
+ */
 class InitialConnection : public std::enable_shared_from_this<InitialConnection> {
 public:
     using NewPlayerVector = thread_safe_vector<std::shared_ptr<NetInterface>>;

--- a/src/Item.hpp
+++ b/src/Item.hpp
@@ -33,107 +33,399 @@ class Character;
 class Container;
 class ItemLookAt;
 
+/**
+ * @brief Represents a game item with properties and custom data.
+ * 
+ * Item is the fundamental class for all in-game objects that can be stored in inventories,
+ * containers, on the ground, or equipped by characters. Each item has:
+ * - A unique type ID determining its properties
+ * - A stack count (number of identical items)
+ * - Wear/durability tracking with automatic degradation
+ * - Quality value encoding both crafting quality and current durability
+ * - Custom data map for script-defined properties
+ * 
+ * Items can be stackable (multiple in one slot), perishable (wear down over time),
+ * or permanent (never decay). Properties like weight, volume, and worth are looked up
+ * from the ItemTable based on the item's ID.
+ * 
+ * @note Quality = (craftingQuality * 100) + durability, where durability ranges 0-99
+ * @see ScriptItem for item instances with positional context
+ * @see ItemTable for item type definitions
+ */
 class Item {
 public:
-    using id_type = uint16_t;
-    using number_type = uint16_t;
-    using wear_type = uint8_t;
-    using quality_type = uint16_t;
-    using datamap_type = std::unordered_map<std::string, std::string>;
+    using id_type = uint16_t; ///< Item type identifier
+    using number_type = uint16_t; ///< Stack count type
+    using wear_type = uint8_t; ///< Wear/durability counter type
+    using quality_type = uint16_t; ///< Quality value combining craft quality and durability
+    using datamap_type = std::unordered_map<std::string, std::string>; ///< Custom script data storage
 
-    static constexpr TYPE_OF_VOLUME LARGE_ITEM_VOLUME = 5000;
-    static constexpr wear_type PERMANENT_WEAR = 255;
-    static constexpr quality_type defaultQuality = 333;
-    static constexpr quality_type maximumQuality = 999;
-    static constexpr quality_type maximumDurability = 99;
+    static constexpr TYPE_OF_VOLUME LARGE_ITEM_VOLUME = 5000; ///< Volume threshold for large items
+    static constexpr wear_type PERMANENT_WEAR = 255; ///< Special wear value indicating item never decays
+    static constexpr quality_type defaultQuality = 333; ///< Default quality for new items (quality 3, durability 33)
+    static constexpr quality_type maximumQuality = 999; ///< Maximum possible quality value (quality 9, durability 99)
+    static constexpr quality_type maximumDurability = 99; ///< Maximum durability component of quality
 
+    /**
+     * @brief Default constructor creating an empty item slot.
+     */
     Item() = default;
+    
+    /**
+     * @brief Creates an item with specified properties.
+     * 
+     * @param id Item type ID from ItemTable
+     * @param number Stack count (1 for non-stackable items)
+     * @param wear Initial wear value (255 for permanent, 0 for destroyed)
+     * @param quality Combined quality value (default = 333)
+     */
     Item(id_type id, number_type number, wear_type wear, quality_type quality = defaultQuality)
             : id(id), number(number), wear(wear), quality(quality), datamap(1) {}
+    
+    /**
+     * @brief Creates an item with custom script data.
+     * 
+     * @param id Item type ID from ItemTable
+     * @param number Stack count
+     * @param wear Initial wear value
+     * @param quality Combined quality value
+     * @param datamap Custom key-value data for scripts
+     */
     Item(id_type id, number_type number, wear_type wear, quality_type quality, const script_data_exchangemap &datamap);
 
-    inline auto getId() const -> id_type { return id; }
-    inline void setId(id_type id) { this->id = id; }
+    inline auto getId() const -> id_type { return id; } ///< @return Item type ID
+    inline void setId(id_type id) { this->id = id; } ///< @param id New item type ID
 
-    inline auto getNumber() const -> number_type { return number; }
-    inline void setNumber(number_type number) { this->number = number; }
+    inline auto getNumber() const -> number_type { return number; } ///< @return Current stack count
+    inline void setNumber(number_type number) { this->number = number; } ///< @param number New stack count
+    
+    /**
+     * @brief Increases stack count up to maximum and returns overflow.
+     * 
+     * @param count Number to add to the stack
+     * @return Overflow count that didn't fit (0 if all fit)
+     */
     auto increaseNumberBy(number_type count) -> number_type;
 
-    inline auto getWear() const -> wear_type { return wear; }
-    inline void setWear(wear_type wear) { this->wear = wear; }
+    inline auto getWear() const -> wear_type { return wear; } ///< @return Current wear value (255 = permanent)
+    inline void setWear(wear_type wear) { this->wear = wear; } ///< @param wear New wear value
 
-    inline auto getQuality() const -> quality_type { return quality; }
-    inline void setQuality(quality_type quality) { this->quality = quality; }
+    inline auto getQuality() const -> quality_type { return quality; } ///< @return Combined quality value
+    inline void setQuality(quality_type quality) { this->quality = quality; } ///< @param quality New quality value
+    
+    /**
+     * @brief Extracts the durability component from quality.
+     * 
+     * @return Durability value (0-99)
+     */
     inline auto getDurability() const -> quality_type { return quality % (maximumDurability + 1); }
+    
+    /**
+     * @brief Sets quality to the minimum of this item and another.
+     * 
+     * Compares both craft quality and durability, taking the lower value of each.
+     * 
+     * @param item The item to compare against
+     */
     void setMinQuality(const Item &item);
 
-    // setData actually does either a clear (if the datamap is nil) or a merge of the keys in datamap
+    /**
+     * @brief Merges or clears custom data from a script data map.
+     * 
+     * If datamap is nullptr, clears all custom data. Otherwise, merges keys from
+     * the provided map into existing data.
+     * 
+     * @param datamap Pointer to data map to merge (nullptr to clear)
+     */
     void setData(script_data_exchangemap const *datamap);
+    
+    /**
+     * @brief Checks if item has all specified data key-value pairs.
+     * 
+     * @param datamap Data to check for
+     * @return true if all keys exist with matching values
+     */
     auto hasData(const script_data_exchangemap &datamap) const -> bool;
+    
+    /**
+     * @brief Checks if item has no custom data.
+     * 
+     * @return true if datamap is empty
+     */
     auto hasNoData() const -> bool;
+    
+    /**
+     * @brief Retrieves a custom data value by key.
+     * 
+     * @param key Data key to look up
+     * @return Value string, or empty string if key doesn't exist
+     */
     auto getData(const std::string &key) const -> std::string;
+    
+    /**
+     * @brief Sets a custom data key-value pair.
+     * 
+     * If value is empty, removes the key. Otherwise, sets or updates the key.
+     * 
+     * @param key Data key
+     * @param value Data value (empty to remove)
+     */
     void setData(const std::string &key, const std::string &value);
+    
+    /**
+     * @brief Sets a custom data key to an integer value.
+     * 
+     * @param key Data key
+     * @param value Integer value (converted to string)
+     */
     void setData(const std::string &key, int32_t value);
-    inline auto getDataBegin() const -> datamap_type::const_iterator { return datamap.cbegin(); }
-    inline auto getDataEnd() const -> datamap_type::const_iterator { return datamap.cend(); }
+    
+    inline auto getDataBegin() const -> datamap_type::const_iterator { return datamap.cbegin(); } ///< @return Iterator to first data entry
+    inline auto getDataEnd() const -> datamap_type::const_iterator { return datamap.cend(); } ///< @return Iterator past last data entry
+    
+    /**
+     * @brief Checks if custom data matches a script data map.
+     * 
+     * @param data Data map to compare (nullptr treated as empty)
+     * @return true if data maps are equal
+     */
     inline auto equalData(script_data_exchangemap const *data) const -> bool {
         Item item;
         item.setData(data);
         return equalData(item);
     }
+    
+    /**
+     * @brief Checks if custom data matches another item's data.
+     * 
+     * @param item Item to compare data against
+     * @return true if data maps are equal
+     */
     inline auto equalData(const Item &item) const -> bool { return datamap == item.datamap; }
 
+    /**
+     * @brief Retrieves the depot ID for this item if it's a depot chest.
+     * 
+     * @return Depot number from custom data (default 1 if not set)
+     */
     auto getDepot() const -> uint16_t;
 
+    /**
+     * @brief Resets item to empty state.
+     * 
+     * Clears all properties and custom data, making this an empty item slot.
+     */
     void reset();
+    
+    /**
+     * @brief Resets wear to item's ageing speed if applicable.
+     * 
+     * For non-rotting items, sets wear to the item type's AgeingSpeed if current
+     * wear is lower.
+     */
     void resetWear();
 
+    /**
+     * @brief Serializes item to binary file stream.
+     * 
+     * @param obj Output file stream
+     */
     void save(std::ofstream &obj) const;
+    
+    /**
+     * @brief Deserializes item from binary file stream.
+     * 
+     * @param obj Input file stream
+     */
     void load(std::ifstream &obj);
 
+    /**
+     * @brief Decrements wear by one and checks if item survives.
+     * 
+     * Items with wear = 0 or PERMANENT_WEAR are not affected.
+     * 
+     * @return true if item still exists (wear > 0), false if destroyed
+     */
     auto survivesAgeing() -> bool;
+    
+    /**
+     * @brief Checks if this item type is a container.
+     * 
+     * @return true if item exists in ContainerObjectTable
+     */
     auto isContainer() const -> bool;
+    
+    /**
+     * @brief Gets the volume per item from ItemTable.
+     * 
+     * @return Volume value, or 0 if item type invalid
+     */
     auto getVolume() const -> TYPE_OF_VOLUME;
+    
+    /**
+     * @brief Gets total weight of this stack.
+     * 
+     * @return Weight per item * stack count, or 0 if invalid
+     */
     auto getWeight() const -> TYPE_OF_WEIGHT;
+    
+    /**
+     * @brief Gets total worth/value of this stack.
+     * 
+     * @return Worth per item * stack count, or 0 if invalid
+     */
     auto getWorth() const -> TYPE_OF_WORTH;
+    
+    /**
+     * @brief Gets maximum stack size for this item type.
+     * 
+     * @return Maximum stack count from ItemTable, or 0 if invalid
+     */
     auto getMaxStack() const -> number_type;
+    
+    /**
+     * @brief Checks if item is considered large.
+     * 
+     * @return true if volume >= LARGE_ITEM_VOLUME
+     */
     auto isLarge() const -> bool;
+    
+    /**
+     * @brief Checks if item can stack with others of same type.
+     * 
+     * @return true if MaxStack > 1
+     */
     auto isStackable() const -> bool;
+    
+    /**
+     * @brief Checks if item never decays.
+     * 
+     * @return true if wear == PERMANENT_WEAR
+     */
     auto isPermanent() const -> bool;
+    
+    /**
+     * @brief Checks if item can be picked up and moved.
+     * 
+     * @return true if weight < MAXWEIGHT and not permanent
+     */
     auto isMovable() const -> bool;
+    
+    /**
+     * @brief Makes item permanent (never decay).
+     */
     void makePermanent();
 
+    /**
+     * @brief Compares all item properties for equality.
+     * 
+     * @param rhs Item to compare against
+     * @return true if all properties match (id, number, wear, quality, datamap)
+     */
     auto operator==(const Item &rhs) const -> bool;
 
 private:
-    id_type id{0};
-    number_type number{0};
-    wear_type wear{0};
-    quality_type quality{defaultQuality};
-    datamap_type datamap{1};
+    id_type id{0}; ///< Item type identifier from ItemTable
+    number_type number{0}; ///< Number of items in this stack
+    wear_type wear{0}; ///< Wear/decay counter (255 = permanent, 0 = destroyed)
+    quality_type quality{defaultQuality}; ///< Combined quality: (craftQuality * 100) + durability
+    datamap_type datamap{1}; ///< Custom script data key-value storage
 };
 
+/**
+ * @brief Extended item with positional and ownership context for script interactions.
+ * 
+ * ScriptItem adds location and ownership information to the base Item class, allowing
+ * Lua scripts to determine where an item is located (field, inventory, container) and
+ * who owns it. This context is essential for:
+ * - Item use scripts that need to know the user
+ * - Container management scripts
+ * - Field trigger items
+ * - Inventory position-specific logic
+ * 
+ * The type field determines how to interpret pos, itempos, owner, and inside:
+ * - it_field: Item on ground (pos = world position, itempos unused)
+ * - it_inventory: In character slot (pos = character position, itempos = slot number)
+ * - it_belt: In character belt (pos = character position, itempos = belt position)
+ * - it_container: In a container (inside = container pointer, itempos = slot in container)
+ * 
+ * @see Item for base item properties
+ * @see ItemLookAt for item examination data
+ */
 class ScriptItem : public Item {
 public:
-    enum itemtype { notdefined = 0, it_field = 3, it_inventory = 4, it_belt = 5, it_container = 6 };
-    static constexpr uint8_t maxItemPos = 255;
+    /**
+     * @brief Identifies where the item is located in the game world.
+     */
+    enum itemtype { 
+        notdefined = 0, ///< Location not set
+        it_field = 3,   ///< Item on a map tile
+        it_inventory = 4, ///< Item in character inventory slot
+        it_belt = 5,    ///< Item in character belt
+        it_container = 6 ///< Item inside a container
+    };
+    
+    static constexpr uint8_t maxItemPos = 255; ///< Maximum valid item position value
 
-    itemtype type{notdefined};
-    position pos{0, 0, 0};
-    unsigned char itempos{maxItemPos};
-    Character *owner{nullptr};
+    itemtype type{notdefined}; ///< Location type of this item instance
+    position pos{0, 0, 0}; ///< World position or owner position depending on type
+    unsigned char itempos{maxItemPos}; ///< Slot/position within inventory, belt, or container
+    Character *owner{nullptr}; ///< Character who owns this item (for inventory/belt types)
+    
+    /**
+     * @brief Gets owner wrapped in a safe pointer for Lua scripts.
+     * 
+     * @return character_ptr wrapper preventing dangling references
+     */
     auto getOwnerForLua() const -> character_ptr {
         character_ptr fuse_owner(owner);
         return fuse_owner;
     };
-    Container *inside{nullptr};
+    
+    Container *inside{nullptr}; ///< Container holding this item (for it_container type)
+    
+    /**
+     * @brief Default constructor creating an empty script item.
+     */
     ScriptItem() : Item(0, 0, 0) {}
+    
+    /**
+     * @brief Gets the location type of this item.
+     * 
+     * @return itemtype enumeration value
+     */
     auto getType() const -> unsigned char { return type; }
+    
+    /**
+     * @brief Creates a ScriptItem from a base Item.
+     * 
+     * @param source Item to copy properties from
+     */
     explicit ScriptItem(const Item &source) : Item(source), itempos(0) {}
 
+    /**
+     * @brief Generates look-at/examination text for this item.
+     * 
+     * Calls the item's LookAtItem script if available, otherwise uses default lookup.
+     * 
+     * @param character The character examining the item
+     * @return ItemLookAt structure with examination details
+     */
     auto getLookAt(Character * /*character*/) const -> ItemLookAt;
 
+    /**
+     * @brief Compares all properties including location context.
+     * 
+     * @param rhs ScriptItem to compare against
+     * @return true if all Item properties and location data match
+     */
     auto operator==(const ScriptItem &rhs) const -> bool;
+    
+    /**
+     * @brief Creates a plain Item copy without location context.
+     * 
+     * @return New Item with same id, number, wear, quality, and custom data
+     */
     auto cloneItem() const -> Item;
 };
 

--- a/src/ItemLookAt.hpp
+++ b/src/ItemLookAt.hpp
@@ -25,140 +25,338 @@
 
 #include <string>
 
+/**
+ * @brief Contains detailed information about an item for display when a player examines it.
+ *
+ * This class stores all the information shown when a player looks at an item,
+ * including its name, description, rarity, crafting details, gem levels, and durability.
+ */
 class ItemLookAt {
 public:
-    static const TYPE_OF_ITEMLEVEL MAX_ITEMLEVEL = 100;
-    static const uint8_t MAX_GEM_LEVEL = 10;
-    static const uint8_t MAX_DURABILITY = 100;
+    static const TYPE_OF_ITEMLEVEL MAX_ITEMLEVEL = 100; ///< Maximum item level.
+    static const uint8_t MAX_GEM_LEVEL = 10; ///< Maximum level for gem enhancements.
+    static const uint8_t MAX_DURABILITY = 100; ///< Maximum durability value.
 
+    /**
+     * @brief Item rarity levels affecting item quality and appearance.
+     */
     enum Rareness {
-        commonItem = 1,
-        uncommonItem = 2,
-        rareItem = 3,
-        epicItem = 4,
+        commonItem = 1,   ///< Common (white) item.
+        uncommonItem = 2, ///< Uncommon (green) item.
+        rareItem = 3,     ///< Rare (blue) item.
+        epicItem = 4,     ///< Epic (purple) item.
     };
 
+    /**
+     * @brief Sets the item's display name.
+     * @param name The name to display.
+     */
     void setName(const std::string &name) { this->name = name; }
+
+    /**
+     * @brief Gets the item's display name.
+     * @return The item name.
+     */
     [[nodiscard]] auto getName() const -> const std::string & { return name; }
 
+    /**
+     * @brief Sets the item's rarity level.
+     * @param rareness The rarity level.
+     */
     void setRareness(Rareness rareness) { this->rareness = rareness; }
+
+    /**
+     * @brief Gets the item's rarity level.
+     * @return The rarity level.
+     */
     [[nodiscard]] auto getRareness() const -> Rareness { return rareness; }
 
+    /**
+     * @brief Sets the item's description text.
+     * @param description The description to display.
+     */
     void setDescription(const std::string &description) { this->description = description; }
+
+    /**
+     * @brief Gets the item's description text.
+     * @return The description.
+     */
     [[nodiscard]] auto getDescription() const -> const std::string & { return description; }
 
+    /**
+     * @brief Sets the name of the character who crafted this item.
+     * @param craftedBy The crafter's name.
+     */
     void setCraftedBy(const std::string &craftedBy) { this->craftedBy = craftedBy; }
+
+    /**
+     * @brief Gets the name of the character who crafted this item.
+     * @return The crafter's name.
+     */
     [[nodiscard]] auto getCraftedBy() const -> const std::string & { return craftedBy; }
 
+    /**
+     * @brief Sets the item's type description.
+     * @param type The type description.
+     */
     void setType(const std::string &type) { this->type = type; }
+
+    /**
+     * @brief Gets the item's type description.
+     * @return The type description.
+     */
     [[nodiscard]] auto getType() const -> const std::string & { return type; }
 
+    /**
+     * @brief Sets the item's level requirement (clamped to MAX_ITEMLEVEL).
+     * @param level The item level.
+     */
     void setLevel(TYPE_OF_ITEMLEVEL level) {
         if (level <= MAX_ITEMLEVEL) {
             this->level = level;
         }
     }
+
+    /**
+     * @brief Gets the item's level requirement.
+     * @return The item level.
+     */
     [[nodiscard]] auto getLevel() const -> TYPE_OF_ITEMLEVEL { return level; }
 
+    /**
+     * @brief Sets whether the item is usable.
+     * @param usable true if the item can be used.
+     */
     void setUsable(bool usable) { this->usable = usable; }
+
+    /**
+     * @brief Checks if the item is usable.
+     * @return true if the item can be used.
+     */
     [[nodiscard]] auto isUsable() const -> bool { return usable; }
 
+    /**
+     * @brief Sets the item's weight.
+     * @param weight The weight value.
+     */
     void setWeight(TYPE_OF_WEIGHT weight) { this->weight = weight; }
+
+    /**
+     * @brief Gets the item's weight.
+     * @return The weight value.
+     */
     [[nodiscard]] auto getWeight() const -> TYPE_OF_WEIGHT { return weight; }
 
+    /**
+     * @brief Sets the item's monetary worth.
+     * @param worth The worth value.
+     */
     void setWorth(TYPE_OF_WORTH worth) { this->worth = worth; }
+
+    /**
+     * @brief Gets the item's monetary worth.
+     * @return The worth value.
+     */
     [[nodiscard]] auto getWorth() const -> TYPE_OF_WORTH { return worth; }
 
+    /**
+     * @brief Sets the quality description text.
+     * @param qualityText The quality description.
+     */
     void setQualityText(const std::string &qualityText) { this->qualityText = qualityText; }
+
+    /**
+     * @brief Gets the quality description text.
+     * @return The quality description.
+     */
     [[nodiscard]] auto getQualityText() const -> const std::string & { return qualityText; }
 
+    /**
+     * @brief Sets the durability description text.
+     * @param durabilityText The durability description.
+     */
     void setDurabilityText(const std::string &durabilityText) { this->durabilityText = durabilityText; }
+
+    /**
+     * @brief Gets the durability description text.
+     * @return The durability description.
+     */
     [[nodiscard]] auto getDurabilityText() const -> const std::string & { return durabilityText; }
 
+    /**
+     * @brief Sets the durability value (clamped to MAX_DURABILITY).
+     * @param durabilityValue The durability value (0-100).
+     */
     void setDurabilityValue(uint8_t durabilityValue) {
         if (durabilityValue <= MAX_DURABILITY) {
             this->durabilityValue = durabilityValue;
         }
     }
+
+    /**
+     * @brief Gets the durability value.
+     * @return The durability value (0-100).
+     */
     [[nodiscard]] auto getDurabilityValue() const -> uint8_t { return durabilityValue; }
 
+    /**
+     * @brief Sets the diamond gem level (clamped to MAX_GEM_LEVEL).
+     * @param diamondLevel The gem level (0-10).
+     */
     void setDiamondLevel(uint8_t diamondLevel) {
         if (diamondLevel <= MAX_GEM_LEVEL) {
             this->diamondLevel = diamondLevel;
         }
     }
+
+    /**
+     * @brief Gets the diamond gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getDiamondLevel() const -> uint8_t { return diamondLevel; }
 
+    /**
+     * @brief Sets the emerald gem level (clamped to MAX_GEM_LEVEL).
+     * @param emeraldLevel The gem level (0-10).
+     */
     void setEmeraldLevel(uint8_t emeraldLevel) {
         if (emeraldLevel <= MAX_GEM_LEVEL) {
             this->emeraldLevel = emeraldLevel;
         }
     }
+
+    /**
+     * @brief Gets the emerald gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getEmeraldLevel() const -> uint8_t { return emeraldLevel; }
 
+    /**
+     * @brief Sets the ruby gem level (clamped to MAX_GEM_LEVEL).
+     * @param rubyLevel The gem level (0-10).
+     */
     void setRubyLevel(uint8_t rubyLevel) {
         if (rubyLevel <= MAX_GEM_LEVEL) {
             this->rubyLevel = rubyLevel;
         }
     }
+
+    /**
+     * @brief Gets the ruby gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getRubyLevel() const -> uint8_t { return rubyLevel; }
 
+    /**
+     * @brief Sets the sapphire gem level (clamped to MAX_GEM_LEVEL).
+     * @param sapphireLevel The gem level (0-10).
+     */
     void setSapphireLevel(uint8_t sapphireLevel) {
         if (sapphireLevel <= MAX_GEM_LEVEL) {
             this->sapphireLevel = sapphireLevel;
         }
     }
+
+    /**
+     * @brief Gets the sapphire gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getSapphireLevel() const -> uint8_t { return sapphireLevel; }
 
+    /**
+     * @brief Sets the amethyst gem level (clamped to MAX_GEM_LEVEL).
+     * @param amethystLevel The gem level (0-10).
+     */
     void setAmethystLevel(uint8_t amethystLevel) {
         if (amethystLevel <= MAX_GEM_LEVEL) {
             this->amethystLevel = amethystLevel;
         }
     }
+
+    /**
+     * @brief Gets the amethyst gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getAmethystLevel() const -> uint8_t { return amethystLevel; }
 
+    /**
+     * @brief Sets the obsidian gem level (clamped to MAX_GEM_LEVEL).
+     * @param obsidianLevel The gem level (0-10).
+     */
     void setObsidianLevel(uint8_t obsidianLevel) {
         if (obsidianLevel <= MAX_GEM_LEVEL) {
             this->obsidianLevel = obsidianLevel;
         }
     }
+
+    /**
+     * @brief Gets the obsidian gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getObsidianLevel() const -> uint8_t { return obsidianLevel; }
 
+    /**
+     * @brief Sets the topaz gem level (clamped to MAX_GEM_LEVEL).
+     * @param topazLevel The gem level (0-10).
+     */
     void setTopazLevel(uint8_t topazLevel) {
         if (topazLevel <= MAX_GEM_LEVEL) {
             this->topazLevel = topazLevel;
         }
     }
+
+    /**
+     * @brief Gets the topaz gem level.
+     * @return The gem level (0-10).
+     */
     [[nodiscard]] auto getTopazLevel() const -> uint8_t { return topazLevel; }
 
+    /**
+     * @brief Sets the item's bonus value.
+     * @param bonus The bonus value.
+     */
     void setBonus(uint8_t bonus) { this->bonus = bonus; }
+
+    /**
+     * @brief Gets the item's bonus value.
+     * @return The bonus value.
+     */
     [[nodiscard]] auto getBonus() const -> uint8_t { return bonus; }
 
+    /**
+     * @brief Compares two ItemLookAt objects for equality.
+     * @param rhs The other ItemLookAt to compare against.
+     * @return true if all properties match.
+     */
     auto operator==(const ItemLookAt &rhs) const -> bool;
 
+    /**
+     * @brief Checks if this ItemLookAt contains valid data.
+     * @return true if the item has a name, false otherwise.
+     */
     [[nodiscard]] auto isValid() const -> bool { return name.length() > 0; }
 
 private:
-    std::string name;
-    Rareness rareness = commonItem;
-    std::string description;
-    std::string craftedBy;
-    std::string type;
-    TYPE_OF_ITEMLEVEL level = 0;
-    bool usable = true;
-    TYPE_OF_WEIGHT weight = 0;
-    TYPE_OF_WORTH worth = 0;
-    std::string qualityText;
-    std::string durabilityText;
-    uint8_t durabilityValue = 0;
-    uint8_t diamondLevel = 0;
-    uint8_t emeraldLevel = 0;
-    uint8_t rubyLevel = 0;
-    uint8_t sapphireLevel = 0;
-    uint8_t amethystLevel = 0;
-    uint8_t obsidianLevel = 0;
-    uint8_t topazLevel = 0;
-    uint8_t bonus = 0;
+    std::string name; ///< The item's display name.
+    Rareness rareness = commonItem; ///< The item's rarity level.
+    std::string description; ///< The item's description text.
+    std::string craftedBy; ///< Name of the character who crafted this item.
+    std::string type; ///< The item's type description.
+    TYPE_OF_ITEMLEVEL level = 0; ///< The item's level requirement.
+    bool usable = true; ///< Whether the item can be used.
+    TYPE_OF_WEIGHT weight = 0; ///< The item's weight.
+    TYPE_OF_WORTH worth = 0; ///< The item's monetary worth.
+    std::string qualityText; ///< Quality description text.
+    std::string durabilityText; ///< Durability description text.
+    uint8_t durabilityValue = 0; ///< Durability value (0-100).
+    uint8_t diamondLevel = 0; ///< Diamond gem enhancement level (0-10).
+    uint8_t emeraldLevel = 0; ///< Emerald gem enhancement level (0-10).
+    uint8_t rubyLevel = 0; ///< Ruby gem enhancement level (0-10).
+    uint8_t sapphireLevel = 0; ///< Sapphire gem enhancement level (0-10).
+    uint8_t amethystLevel = 0; ///< Amethyst gem enhancement level (0-10).
+    uint8_t obsidianLevel = 0; ///< Obsidian gem enhancement level (0-10).
+    uint8_t topazLevel = 0; ///< Topaz gem enhancement level (0-10).
+    uint8_t bonus = 0; ///< Item bonus value.
 };
 
 #endif

--- a/src/Language.hpp
+++ b/src/Language.hpp
@@ -19,6 +19,14 @@
 #ifndef LANGUAGE_HPP
 #define LANGUAGE_HPP
 
-enum class Language { german = 0, english = 1 };
+/**
+ * @brief Supported languages for the game server.
+ *
+ * This enum represents the available languages for game text and communication.
+ */
+enum class Language { 
+    german = 0,  ///< German language.
+    english = 1  ///< English language.
+};
 
 #endif

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -24,52 +24,121 @@
 #include <syslog.h>
 #include <type_traits>
 
+/**
+ * @brief Logging facility categories for organizing log messages.
+ *
+ * Each facility corresponds to a syslog LOCAL facility for filtering and routing.
+ */
 enum class LogFacility {
-    Database = LOG_LOCAL1,
-    World = LOG_LOCAL2,
-    Script = LOG_LOCAL3,
-    Player = LOG_LOCAL4,
-    Chat = LOG_LOCAL5,
-    Admin = LOG_LOCAL6,
-    Other = LOG_LOCAL7
+    Database = LOG_LOCAL1, ///< Database-related operations.
+    World = LOG_LOCAL2,    ///< World and game mechanics.
+    Script = LOG_LOCAL3,   ///< Script execution and errors.
+    Player = LOG_LOCAL4,   ///< Player actions and events.
+    Chat = LOG_LOCAL5,     ///< Chat and communication.
+    Admin = LOG_LOCAL6,    ///< Administrative actions.
+    Other = LOG_LOCAL7     ///< Miscellaneous messages.
 };
 
+/**
+ * @brief Logging priority levels from emergency to debug.
+ *
+ * These correspond to standard syslog priority levels.
+ */
 enum class LogPriority {
-    EMERGENCY = LOG_EMERG,
-    ALERT = LOG_ALERT,
-    CRITICAL = LOG_CRIT,
-    ERROR = LOG_ERR,
-    WARNING = LOG_WARNING,
-    NOTICE = LOG_NOTICE,
-    INFO = LOG_INFO,
-    DEBUG = LOG_DEBUG
+    EMERGENCY = LOG_EMERG, ///< System is unusable.
+    ALERT = LOG_ALERT,     ///< Action must be taken immediately.
+    CRITICAL = LOG_CRIT,   ///< Critical conditions.
+    ERROR = LOG_ERR,       ///< Error conditions.
+    WARNING = LOG_WARNING, ///< Warning conditions.
+    NOTICE = LOG_NOTICE,   ///< Normal but significant condition.
+    INFO = LOG_INFO,       ///< Informational messages.
+    DEBUG = LOG_DEBUG      ///< Debug-level messages.
 };
 
+/**
+ * @brief Compile-time check if a log priority is enabled.
+ * @param priority The priority level to check.
+ * @return true if the priority should be logged, false if it should be optimized out.
+ * @note DEBUG level is currently disabled at compile time.
+ */
 constexpr auto isLogEnabled(LogPriority priority) -> bool { return priority != LogPriority::DEBUG; }
 
+/**
+ * @brief Sends a log message to syslog.
+ * @param priority The priority level of the message.
+ * @param facility The facility category for the message.
+ * @param message The message text to log.
+ */
 void log_message(LogPriority priority, LogFacility facility, const std::string &message);
 
+/**
+ * @brief Logging utilities and stream manipulators.
+ */
 namespace Log {
+/**
+ * @brief Stream manipulator to end and flush a log message.
+ */
 class end_t {};
-static const end_t end __attribute__((unused));
+static const end_t end __attribute__((unused)); ///< Log stream terminator.
 } // namespace Log
 
+/**
+ * @brief No-op stream that discards all input for disabled log levels.
+ *
+ * This is used for compile-time optimization of disabled log levels,
+ * ensuring zero runtime overhead for disabled logging.
+ */
 class NullStream {
 public:
+    /**
+     * @brief Default constructor.
+     */
     inline constexpr NullStream() = default;
+
+    /**
+     * @brief No-op facility setter.
+     * @param facility The facility (ignored).
+     * @return Reference to self for chaining.
+     */
     inline auto operator()(LogFacility facility) const -> const NullStream & { return *this; }
 
+    /**
+     * @brief No-op insertion operator that discards all data.
+     * @tparam T Any type (discarded).
+     * @param unused The value to discard.
+     * @return Reference to self for chaining.
+     */
     template <typename T> inline auto operator<<(const T & /*unused*/) const -> const NullStream & { return *this; }
 };
 
+/**
+ * @brief Active log stream that accumulates messages and sends them to syslog.
+ * @tparam priority The priority level for this stream.
+ */
 template <LogPriority priority> class LogStream {
 public:
+    /**
+     * @brief Sets the logging facility for this message.
+     * @param facility The facility category.
+     * @return Reference to self for chaining.
+     */
     inline auto operator()(LogFacility facility) -> LogStream & {
         _facility = facility;
         return *this;
     }
 
+    /**
+     * @brief Default constructor.
+     */
     inline LogStream() = default;
+
+    /**
+     * @brief Insertion operator to append data to the log message.
+     * @tparam T The type of data to append.
+     * @param data The data to append.
+     * @return Reference to self for chaining.
+     * @note Pointers (except char*) are not allowed for safety.
+     */
     template <typename T> inline auto operator<<(const T &data) -> LogStream & {
         static_assert(!std::is_pointer<T>::value || std::is_same<T, const char *>::value ||
                               std::is_same<T, char *>::value,
@@ -78,6 +147,11 @@ public:
         return *this;
     }
 
+    /**
+     * @brief Logs and flushes the accumulated message.
+     * @param unused The Log::end manipulator.
+     * @return Reference to self for chaining.
+     */
     auto operator<<(const Log::end_t & /*unused*/) -> LogStream & {
         log_message(priority, _facility, _ss.str());
         _ss.str({});
@@ -85,25 +159,41 @@ public:
     }
 
 private:
-    std::stringstream _ss;
-    LogFacility _facility = LogFacility::Other;
+    std::stringstream _ss;                      ///< Accumulator for the log message.
+    LogFacility _facility = LogFacility::Other; ///< The facility for this message.
 };
 
+/**
+ * @brief Type selector that chooses between active LogStream and NullStream.
+ * @tparam priority The priority level to check.
+ *
+ * At compile time, selects NullStream for disabled priorities (zero overhead)
+ * or LogStream for enabled priorities.
+ */
 template <LogPriority priority> class LogType {
 public:
-    using type = std::conditional_t<isLogEnabled(priority), LogStream<priority>, NullStream>;
+    using type = std::conditional_t<isLogEnabled(priority), LogStream<priority>, NullStream>; ///< The selected type.
 };
 
+/**
+ * @brief Static logging interface with priority-specific streams.
+ *
+ * Usage:
+ * @code
+ * Logger::error(LogFacility::Database) << "Connection failed: " << error << Log::end;
+ * Logger::info(LogFacility::Player) << "Player " << name << " logged in" << Log::end;
+ * @endcode
+ */
 class Logger {
 public:
-    static LogType<LogPriority::EMERGENCY>::type emergency;
-    static LogType<LogPriority::ALERT>::type alert;
-    static LogType<LogPriority::CRITICAL>::type critical;
-    static LogType<LogPriority::ERROR>::type error;
-    static LogType<LogPriority::WARNING>::type warn;
-    static LogType<LogPriority::NOTICE>::type notice;
-    static LogType<LogPriority::INFO>::type info;
-    static LogType<LogPriority::DEBUG>::type debug;
+    static LogType<LogPriority::EMERGENCY>::type emergency; ///< Emergency level logging.
+    static LogType<LogPriority::ALERT>::type alert;         ///< Alert level logging.
+    static LogType<LogPriority::CRITICAL>::type critical;   ///< Critical level logging.
+    static LogType<LogPriority::ERROR>::type error;         ///< Error level logging.
+    static LogType<LogPriority::WARNING>::type warn;        ///< Warning level logging.
+    static LogType<LogPriority::NOTICE>::type notice;       ///< Notice level logging.
+    static LogType<LogPriority::INFO>::type info;           ///< Info level logging.
+    static LogType<LogPriority::DEBUG>::type debug;         ///< Debug level logging (disabled).
 };
 
 #endif

--- a/src/LongTimeAction.hpp
+++ b/src/LongTimeAction.hpp
@@ -38,6 +38,12 @@ enum LtaState : unsigned char {
     ST_SUCCESS = 2 /**< action was sucessfully*/
 };
 
+/**
+ * @brief Parameters passed to Lua scripts for various action callbacks.
+ * 
+ * Contains context information about the source of an action (character, item,
+ * field position, dialog, or text) to provide scripts with necessary data.
+ */
 struct ActionParameters {
     Character *character = nullptr;
     ScriptItem item;
@@ -49,9 +55,13 @@ struct ActionParameters {
 };
 
 /**
+ * @brief Manages long-duration player actions that can be interrupted.
+ * 
+ * Tracks actions like crafting, using items, or casting spells that take time to complete.
+ * Actions can be aborted by combat, movement, or other disruptions, and trigger Lua
+ * script callbacks on success or failure.
+ * 
  * @ingroup Scriptclasses
- * class which holds the last action of the player for recalling the script on success or aborting the script
- * exportet to lua as <b>action</b>
  */
 class LongTimeAction {
 public:

--- a/src/LongTimeCharacterEffects.hpp
+++ b/src/LongTimeCharacterEffects.hpp
@@ -29,6 +29,12 @@
 
 class Character;
 
+/**
+ * @brief Manages all long-term effects active on a single character.
+ * 
+ * Maintains a collection of LongTimeEffect instances, handles effect execution timing,
+ * persistence to database, and provides lookup/removal operations.
+ */
 class LongTimeCharacterEffects {
 public:
     explicit LongTimeCharacterEffects(Character *owner);

--- a/src/LongTimeEffect.hpp
+++ b/src/LongTimeEffect.hpp
@@ -28,6 +28,12 @@ class Character;
 class Player;
 struct LTEPriority;
 
+/**
+ * @brief Represents a timed magical or status effect applied to a character.
+ * 
+ * Long-term effects can modify attributes, apply damage over time, or trigger periodic
+ * script callbacks. Each effect has an execution schedule and can store custom data values.
+ */
 class LongTimeEffect {
 public:
     LongTimeEffect(uint16_t effectId, int32_t executeIn);
@@ -65,6 +71,11 @@ private:
     VALUES values;
 };
 
+/**
+ * @brief Priority comparator for long-term effect execution ordering.
+ * 
+ * Orders effects by execution time for priority queue processing.
+ */
 struct LTEPriority {
     template <typename LTEPointer> auto operator()(const LTEPointer &lhs, const LTEPointer &rhs) const -> bool {
         // effects with higher execution time have lower priority

--- a/src/MonitoringClients.hpp
+++ b/src/MonitoringClients.hpp
@@ -27,8 +27,10 @@ class World;
 class Player;
 
 /**
- * class which holds all the monitoring clients on the gameserver
- * and sends all the important server informations to them
+ * @brief Manages server monitoring clients that observe game state.
+ * 
+ * Maintains connections to administrative monitoring tools and broadcasts
+ * server status, player activity, and diagnostic information.
  */
 class MonitoringClients {
 public:

--- a/src/Monster.hpp
+++ b/src/Monster.hpp
@@ -25,115 +25,199 @@
 class SpawnPoint;
 
 /**
+ * @brief Represents a computer-controlled hostile or neutral creature in the game world.
+ * 
+ * Monsters are AI-controlled characters that spawn from SpawnPoints and can engage in combat.
+ * They have randomized attributes based on their monster type definition and can:
+ * - Attack players and other characters
+ * - Drop loot when killed
+ * - Execute custom Lua scripts for behavior (attack, death, speech reception)
+ * - Navigate toward targets using A* pathfinding
+ * - Heal themselves periodically
+ * - Remember last seen target positions for pursuit
+ * 
+ * Each monster is assigned a unique ID from the MONSTER_BASE range and maintains a reference
+ * to its SpawnPoint for respawn management.
+ * 
  * @ingroup Scriptclasses
- * a monster in the game world
+ * @see Character
+ * @see SpawnPoint
+ * @see MonsterTable
+ * @note Monsters are non-copyable and non-movable
  */
 class Monster : public Character {
 public:
     /**
-     * an exception which is thrown if a id for the monster is unknown
+     * @brief Exception thrown when attempting to set an invalid monster type ID.
+     * 
+     * @see setMonsterType()
      */
     class unknownIDException {};
 
     /**
-     * the constructor which creates the monster on the map
-     * @param type the monster type of this monster
-     * @param newpos the position where the monster should be spawned
-     * @param spawnpoint the spawnpoint from which the monster was spawned ( 0 if there is no spawnpoint )
+     * @brief Creates a new monster at the specified position.
+     * 
+     * Initializes the monster with randomized attributes based on its type definition from
+     * MonsterTable. The monster is assigned a unique ID from the MONSTER_BASE range.
+     * 
+     * @param type The monster type ID to create (must exist in MonsterTable)
+     * @param newpos The world position where the monster spawns
+     * @param spawnpoint Optional pointer to the SpawnPoint that created this monster (nullptr if spawned manually)
+     * 
+     * @throws unknownIDException if the monster type does not exist in MonsterTable
+     * @see setMonsterType()
      */
     Monster(const TYPE_OF_CHARACTER_ID &type, const position &newpos, SpawnPoint *spawnpoint = nullptr);
 
+    /**
+     * @brief Retrieves the loot table for this monster type.
+     * 
+     * @return Reference to the monster's loot configuration
+     * @throws NoLootFound if the monster type has no loot defined
+     */
     auto getLoot() const -> const MonsterStruct::loottype & override;
 
+    /**
+     * @brief Returns the character type identifier.
+     * 
+     * @return Always returns 'monster' constant
+     */
     auto getType() const -> unsigned short override { return monster; }
 
     /**
-     * sets the type of the monster and changes
-     * so the attributes etc for this monster
-     * @param type the new type of the monster
-     * @throw unknownIDException
+     * @brief Changes the monster's type and resets all attributes accordingly.
+     * 
+     * Completely reinitializes the monster with new randomized attributes, skills, items,
+     * appearance, and behavior from the new monster type definition. Clears existing skills
+     * before applying new ones.
+     * 
+     * @param type The new monster type ID
+     * @throws unknownIDException if the type does not exist in MonsterTable
      */
     void setMonsterType(TYPE_OF_CHARACTER_ID type);
 
     /**
-     * sets the spawnpoint for thins monster to a new one
-     * @param sp the pointer to the new spawnpoint
+     * @brief Associates this monster with a different spawn point.
+     * 
+     * @param sp Pointer to the new SpawnPoint (can be nullptr to detach from spawn point)
      */
     void setSpawn(SpawnPoint *sp);
 
     /**
-     * sets the alive state of the monster
-     * if a monster is killed it will be removed from his spawnpoint
-     * @param t the new lifestate true = alive false = death
+     * @brief Sets the alive/dead state and triggers death events.
+     * 
+     * When a monster dies (t = false), this calls the monster's onDeath Lua script
+     * if one exists. The associated SpawnPoint is notified through the destructor.
+     * 
+     * @param t The new life state (true = alive, false = dead)
+     * @note Overrides Character::setAlive() to add script callbacks
      */
     void setAlive(bool t) override;
 
+    /**
+     * @brief Removes the monster from the game world without triggering spawn point notifications.
+     * 
+     * This directly sets alive to false using Character::setAlive(), bypassing the death
+     * script callbacks and spawn point cleanup that would occur with Monster::setAlive().
+     */
     void remove();
 
+    /**
+     * @brief Returns a debug string representation of the monster.
+     * 
+     * @return String in format "Monster of race X(ID)"
+     */
     auto to_string() const -> std::string override;
 
     /**
-     * the monster gets a talked text from a character near starts a script entry point
-     * @param tt how loudly the text is spoken
-     * @param message the message which is spoken
-     * @param cc the character who has spoken the message
+     * @brief Processes speech received from nearby characters.
+     * 
+     * If the monster has a Lua script with a receiveText entry point, this triggers
+     * the script callback. Monsters cannot receive text from themselves.
+     * 
+     * @param tt The speech volume/type (whisper, say, shout, etc.)
+     * @param message The spoken text
+     * @param cc The character who spoke (nullptr if system message)
      */
     void receiveText(talk_type tt, const std::string &message, Character *cc) override;
 
     /**
-     * returns the spawnpoint of the monster
-     * @return the spawnpoint of this monster
+     * @brief Retrieves the SpawnPoint that created this monster.
+     * 
+     * @return Pointer to the spawn point, or nullptr if spawned manually
      */
     inline auto getSpawn() const -> SpawnPoint * { return spawn; }
 
     /**
-     * returns the type of this monster
-     * @return the type
+     * @brief Returns the monster's type identifier.
+     * 
+     * @return The monster type ID used to look up definition in MonsterTable
      */
     auto getMonsterType() const -> TYPE_OF_CHARACTER_ID override { return monstertype; }
 
     /**
-     * the monster is attacking another character starts a script entry
-     * @param target the character which is attacked
-     * @return no usage at this time anything can be returned
+     * @brief Initiates an attack on a target character.
+     * 
+     * Calls the monster's onAttack Lua script before delegating to Character::attack().
+     * 
+     * @param target The character to attack
+     * @return Result of the attack action (currently unused)
      */
     auto attack(Character *target) -> bool override;
 
+    /**
+     * @brief Restores hitpoints and mana by a fixed amount.
+     * 
+     * Increases both hitpoints and mana by monsterSelfHealAmount (defined in tuningConstants.hpp).
+     */
     void heal();
 
     /**
-     *trys to find a path to the the targetposition and performs a step
-     *in the direction
-     *@param targetpos targetposition for the move;
+     * @brief Moves the monster one step toward a target position using pathfinding.
+     * 
+     * Uses A* pathfinding to calculate a route to targetpos. If the current waypoint doesn't
+     * match the target or no valid path exists, recalculates the route. Falls back to random
+     * movement if pathfinding fails.
+     * 
+     * @param targetpos The destination position to move toward
      */
     void performStep(position targetpos);
 
+    /**
+     * @brief Destructor that notifies the spawn point of monster death.
+     * 
+     * If this monster was created by a SpawnPoint, informs it that this monster type
+     * has died so it can schedule a respawn.
+     */
     ~Monster() override;
     Monster(const Monster &) = delete;
     auto operator=(const Monster &) -> Monster & = delete;
     Monster(Monster &&) = delete;
     auto operator=(Monster &&) -> Monster & = delete;
 
-    position lastTargetPosition{}; /**< last position of the last seen target */
-    bool lastTargetSeen =
-            false; /**< if true the monster trys to reach the last targetposition if there is no other enemy*/
+    position lastTargetPosition{}; ///< Last known position of the most recent enemy target
+    bool lastTargetSeen = false; ///< If true, monster will pursue lastTargetPosition when no enemies are visible
 
     /**
-     * checks if the monster can attack onther one or it is a peacefull monster
-     * @return true if the monster is aggresive otherwise false
+     * @brief Checks if this monster can initiate attacks.
+     * 
+     * @return true if the monster is aggressive and can attack, false for peaceful monsters
      */
     inline auto canAttack() const -> bool { return _canAttack; }
 
-    std::string nameDe;
+    std::string nameDe; ///< German localized name of the monster
 
 protected:
+    /**
+     * @brief Default constructor for subclass use only.
+     */
     Monster() = default;
 
 private:
-    static uint32_t counter;
-    SpawnPoint *spawn = nullptr;
-    TYPE_OF_CHARACTER_ID monstertype = 0;
-    bool _canAttack = true;
+    static uint32_t counter; ///< Global counter for generating unique monster IDs
+    SpawnPoint *spawn = nullptr; ///< The spawn point that created this monster (nullptr if spawned manually)
+    TYPE_OF_CHARACTER_ID monstertype = 0; ///< Monster type ID for looking up definition in MonsterTable
+    bool _canAttack = true; ///< Whether this monster can initiate combat
 };
 
 #endif

--- a/src/NewClientView.hpp
+++ b/src/NewClientView.hpp
@@ -31,7 +31,10 @@ class Field;
 }
 
 /**
- * class which holds isometric view specific data
+ * @brief Manages isometric view stripe data for client rendering.
+ * 
+ * Stores field pointers in stripes (rows/columns) that represent the player's
+ * visible area. Used to efficiently send map updates to the client.
  */
 class NewClientView {
 public:

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1019,6 +1019,11 @@ void Player::check_logindata() {
     }
 }
 
+/**
+ * @brief Helper structure for serializing nested containers during player save.
+ * 
+ * Stores container references with their IDs for database persistence.
+ */
 struct container_struct {
     Container *container;
     unsigned int id;

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -41,439 +41,988 @@ class Dialog;
 class Timer;
 class LongTimeAction;
 
+/**
+ * @brief GM permission flags for administrative commands
+ * 
+ * Bitflags controlling which GM commands a player can access.
+ */
 enum gm_rights {
-    gmr_allowlogin = 1,    // GM is allowed to login if nologin is true
-    gmr_basiccommands = 2, // Basic Commands like !who !what !? !fi and !inform
-    gmr_warp = 4,          // GM is allowed to Warp (includes #jump_to)
-    gmr_summon = 8,        // GM is allowed to Summon
-    gmr_undef = 16,
-    gmr_settiles = 32,    // GM is allowed to change tiles (includes ton and toff command)
-    gmr_clipping = 64,    // GM is allowed to change his clipping state (Walk trough walls)
-    gmr_warpfields = 128, // GM is allowed to manipulate Warpfields
-    gmr_import = 256,     // GM is allowed to import maps and Warpfields. includes also createArea
-    gmr_visible = 512,    // GM is allowed to change his visiblity state
-    gmr_reload = 1024, // GM is allowed to reload the tabels (With #r or !rd) includes the right to set the spawnstate
-                       // !setspawn
-    gmr_ban = 2048,    // GM is allowed to ban players.
-    gmr_loginstate = 4096,      // GM is allowed to change loginstate
-    gmr_save = 8192,            // GM is allowed to save players and maps (!playersave and #mapsave)
-    gmr_broadcast = 16384,      // GM is allowed to broadcast messages
-    gmr_forcelogout = 32768,    // GM is allowed to force a logout of players
-    gmr_getgmcalls = 65536,     // Char gets GM messages
-    gmr_isnotshownasgm = 131072 // Char is not shown at gm in the list/ has no officially gm state.
+    gmr_allowlogin = 1,         ///< Can login when server is closed
+    gmr_basiccommands = 2,      ///< Basic commands (!who, !what, !fi, !inform)
+    gmr_warp = 4,               ///< Can warp (#jump_to)
+    gmr_summon = 8,             ///< Can summon players
+    gmr_undef = 16,             ///< Undefined/reserved
+    gmr_settiles = 32,          ///< Can modify tiles (ton/toff)
+    gmr_clipping = 64,          ///< Can walk through walls
+    gmr_warpfields = 128,       ///< Can manipulate warp fields
+    gmr_import = 256,           ///< Can import maps/warpfields (includes createArea)
+    gmr_visible = 512,          ///< Can change visibility state
+    gmr_reload = 1024,          ///< Can reload tables (#r, !rd, !setspawn)
+    gmr_ban = 2048,             ///< Can ban players
+    gmr_loginstate = 4096,      ///< Can change login state
+    gmr_save = 8192,            ///< Can save players/maps (!playersave, #mapsave)
+    gmr_broadcast = 16384,      ///< Can broadcast messages
+    gmr_forcelogout = 32768,    ///< Can force logout players
+    gmr_getgmcalls = 65536,     ///< Receives GM help messages
+    gmr_isnotshownasgm = 131072 ///< Hidden from GM list (unofficial GM state)
 };
 
+/**
+ * @brief Player character controlled by a human client
+ * 
+ * Extends Character with network communication, client UI management, and player-specific
+ * features including:
+ * - Network connection and command processing
+ * - Client UI (showcases, dialogs, inventory displays)
+ * - Quest tracking and progress
+ * - Player knowledge system (knows/introduces other players)
+ * - GM administrative commands and permissions
+ * - Save/load to database
+ * - Crafting and merchant interactions
+ * - Screen updates and visibility management
+ * 
+ * @note Most virtual methods from Character are overridden to send updates to client
+ */
 class Player : public Character {
 public:
-    ////////////////////////////////////////
-    // possible Exceptions thrown by Player
-    ////////////////////////////////////////
-    // exception is thrown if logout of player is only possible result
+    /**
+     * @brief Exception thrown when player must be logged out
+     * 
+     * Used when player authentication fails, data is corrupt, or server rejects login.
+     */
     class LogoutException {
     public:
+        /**
+         * @brief Constructs logout exception with reason code
+         * @param reason Logout reason code
+         */
         explicit LogoutException(const char &reason) : m_reason(reason) {}
+
+        /**
+         * @brief Gets logout reason code
+         * @return Reason code
+         */
         [[nodiscard]] inline auto getReason() const -> const char & { return m_reason; }
 
     private:
-        char m_reason;
+        char m_reason; ///< Logout reason code
     };
 
+    /**
+     * @brief Look mode for examining items/characters
+     */
     enum class LookMode { look = 0, stare = 1 };
 
+    /**
+     * @brief View direction for screen updates
+     */
     enum viewdir { upper = 0, right = 1, lower = 2, left = 3 };
 
+    /**
+     * @brief Gets character type
+     * @return Always returns player type
+     */
     auto getType() const -> unsigned short override { return player; }
 
+    /**
+     * @brief Gets string representation of player
+     * @return Player description string
+     */
     auto to_string() const -> std::string override;
 
+    /**
+     * @brief Processes pending client commands
+     */
     void workoutCommands();
+
+    /**
+     * @brief Checks and updates fight mode state
+     */
     void checkFightMode();
 
-    std::shared_ptr<NetInterface> Connection;
+    std::shared_ptr<NetInterface> Connection; ///< Network connection to client
 
-    //! die letzte IP des Spielers als std::string
-    std::string last_ip;
+    std::string last_ip; ///< Last known IP address
 
-    // BYTEDEQUE//
-    //! alle Langzeiteffekte die auf den Spieler einwirken
-    int longTimeEffects{};
+    int longTimeEffects{}; ///< Count of active long-term effects
 
-    //! Passwort
-    std::string pw;
+    std::string pw;    ///< Password hash
+    std::string email; ///< Email address
 
-    //! E-Mail
-    std::string email;
+    bool newPlayer = false; ///< True if newly created character
 
-    bool newPlayer = false;
+    unsigned long int onlinetime{}; ///< Total time online in seconds
 
-    //! Zeit (in Sekunden) die der Spieler insgesamt online war
-    unsigned long int onlinetime{};
+    time_t logintime{};     ///< Time of current login
+    time_t lastsavetime{};  ///< Last database save time
+    time_t lastkeepalive{}; ///< Last keepalive from client
+    time_t lastaction{};    ///< Last player action time
 
-    time_t logintime{};
+    std::chrono::time_point<std::chrono::steady_clock> reachingTargetField = {}; ///< Movement timing
 
-    //! Zeitpunkt zu dem die Klasseninstanz erstellt bzw. das letzte mal gespeichert wurde
-    time_t lastsavetime{};
+    std::string location; ///< Player location (for profile)
+    std::string realname; ///< Real name (for profile)
 
-    //! Zeitpunkt der letzten Lebensmeldung vom Client
-    time_t lastkeepalive{};
+    uint8_t screenwidth{0};  ///< Client screen width
+    uint8_t screenheight{0}; ///< Client screen height
 
-    //! Zeitpunkt der letzten Aktion des Spielers
-    time_t lastaction{};
-
-    std::chrono::time_point<std::chrono::steady_clock> reachingTargetField = {};
-
-    //! Location
-    std::string location;
-
-    //! Realer Name
-    std::string realname;
-
-    //! Screen resolution;
-    uint8_t screenwidth{0};
-    uint8_t screenheight{0};
-
+    /**
+     * @brief Gets screen/view range based on resolution
+     * @return View distance
+     */
     auto getScreenRange() const -> Coordinate override;
 
 private:
+    /**
+     * @brief Checks if item ID is in depot array
+     * @param itemId Item ID to check
+     * @return True if in depot
+     */
     bool isIdInDepotArray(int itemId);
-    std::set<uint32_t> visibleChars;
-    std::unordered_set<TYPE_OF_CHARACTER_ID> knownPlayers;
-    std::unordered_map<TYPE_OF_CHARACTER_ID, std::string> namedPlayers;
+
+    std::set<uint32_t> visibleChars;                                     ///< Character IDs visible to player
+    std::unordered_set<TYPE_OF_CHARACTER_ID> knownPlayers;               ///< Players this player knows
+    std::unordered_map<TYPE_OF_CHARACTER_ID, std::string> namedPlayers;  ///< Custom names for players
+
     using CLIENTCOMMANDLIST = std::queue<ClientCommandPointer>;
-    CLIENTCOMMANDLIST immediateCommands;
-    CLIENTCOMMANDLIST queuedCommands;
-    std::mutex commandMutex;
+    CLIENTCOMMANDLIST immediateCommands; ///< High-priority commands
+    CLIENTCOMMANDLIST queuedCommands;    ///< Normal priority commands
+    std::mutex commandMutex;             ///< Protects command queues
 
 public:
+    /**
+     * @brief Receives command from client for processing
+     * @param cmd Command pointer
+     */
     void receiveCommand(const ClientCommandPointer &cmd);
 
+    /**
+     * @brief Stops attack and updates client
+     */
     void stopAttack() override;
 
+    /**
+     * @brief Checks if player is newly created
+     * @return True if new player
+     */
     auto isNewPlayer() const -> bool override;
 
+    /**
+     * @brief Native language selector
+     * @param german German text
+     * @param english English text
+     * @return Reference to text in player's language
+     */
     auto nls(const std::string &german, const std::string &english) const -> const std::string &;
 
+    /**
+     * @brief Sets alive state and handles death
+     * @param alive New alive state
+     */
     void setAlive(bool alive) override;
 
+    /**
+     * @brief Checks and updates burden/overtaxed state
+     */
     void checkBurden();
 
+    /**
+     * @brief Sends GM page/help request
+     * @param ticket Help message
+     * @return True if sent
+     */
     auto pageGM(const std::string &ticket) -> bool override;
 
-    // send a char appearance; always or only if char not yet visible
+    /**
+     * @brief Sends character appearance to client
+     * @param id Character ID
+     * @param appearance Appearance command
+     * @param always Force send even if already visible
+     */
     void sendCharAppearance(TYPE_OF_CHARACTER_ID id, const ServerCommandPointer &appearance, bool always);
 
-    // removes a Char from sight
+    /**
+     * @brief Removes character from client view
+     * @param id Character ID
+     * @param removechar Remove command
+     */
     void sendCharRemove(TYPE_OF_CHARACTER_ID id, const ServerCommandPointer &removechar);
 
-    /**
-     *a long time needed action for the player
-     */
-    std::unique_ptr<LongTimeAction> ltAction;
+    std::unique_ptr<LongTimeAction> ltAction; ///< Current long-time action
 
+    // Long-time action management
+    /**
+     * @brief Starts long-time action with UI feedback
+     * @param wait Time to completion (1/10 seconds)
+     * @param ani Animation ID
+     * @param redoani Animation repeat interval
+     * @param sound Sound ID
+     * @param redosound Sound repeat interval
+     */
     void startAction(unsigned short int wait, unsigned short int ani = 0, unsigned short int redoani = 0,
                      unsigned short int sound = 0, unsigned short int redosound = 0) override;
+
+    /**
+     * @brief Aborts current action
+     */
     void abortAction() override;
+
+    /**
+     * @brief Marks action as successful
+     */
     void successAction() override;
+
+    /**
+     * @brief Handles action disturbance
+     * @param disturber Character that disturbed action
+     */
     void actionDisturbed(Character *disturber) override;
 
     /**
-     *changes the source of the last action of this Player
-     *<b>Lua: [:changeSource]</b>
-     *@param cc source is a character the pointer to this character
+     * @brief Changes action source to character
+     * @param cc Source character
+     * @note Lua: [:changeSource]
      */
     void changeSource(Character *cc) override;
 
     /**
-     *changes the source of the last action for this player
-     *<b>Lua: [:changeSource]</b>
-     *@param sI source is a item the new item
+     * @brief Changes action source to item
+     * @param sI Source item
+     * @note Lua: [:changeSource]
      */
     void changeSource(const ScriptItem &sI) override;
 
     /**
-     *changes the Source of the last action for this player.
-     *<b>Lua: [:changeSource]</b>
-     *@param pos source is a position the new position
+     * @brief Changes action source to position
+     * @param pos Source position
+     * @note Lua: [:changeSource]
      */
     void changeSource(const position &pos) override;
 
     /**
-     * Changes the Source of the last action for this player.
-     * Also sets the ActionType to TALK and aborts other non-talk actions currently active.
-     * <b>Lua: [:changeSource]</b>
-     * @param text the text of the player talk.
-     * @param talkType the type of player talk done (whisper, shout, talk).
+     * @brief Changes action source to speech and aborts non-talk actions
+     * @param text Speech text
+     * @param talkType Talk type
+     * @note Lua: [:changeSource]
      */
     void changeSource(const std::string &text, talk_type talkType) override;
 
     /**
-     *changes the Source of the last action to nothing for this player
-     *<b>Lua: [:changeSource]</b>
+     * @brief Clears action source
+     * @note Lua: [:changeSource]
      */
     void changeSource() override;
 
     /**
-     * returns the number of seconds the player has been idle, not actively issuing commands
-     * <b>Lua: [:idleTime]</b>
-     * @return number of seconds the player has been idle
+     * @brief Gets idle time since last action
+     * @return Seconds idle
+     * @note Lua: [:idleTime]
      */
     auto idleTime() const -> uint32_t override;
 
     /**
-     * send a book ID to the client
-     * <b>Lua: [:sendBook]</b>
-     * @param bookID id of the book
+     * @brief Sends book to client
+     * @param bookID Book ID
+     * @note Lua: [:sendBook]
      */
     void sendBook(uint16_t bookID) override;
 
     /**
-     * send a character description to the player if the  char is a player
-     * <b>Lua: [:sendCharDescription]</b>
-     * @param id of the character from which the description is sended
-     * @param desc the current descpription
+     * @brief Sends character description to client
+     * @param id Character ID
+     * @param desc Description text
+     * @note Lua: [:sendCharDescription]
      */
     void sendCharDescription(TYPE_OF_CHARACTER_ID id, const std::string &desc) override;
 
-    //! normal constructor
+    // Constructors and initialization
+    /**
+     * @brief Constructs player with network connection
+     * @param newConnection Client connection
+     * @throws LogoutException if authentication/loading fails
+     */
     explicit Player(std::shared_ptr<NetInterface> newConnection);
 
-    // testing constructor
+    /**
+     * @brief Default constructor for testing
+     */
     Player() = default;
 
-    //! check if username/password is ok
+    /**
+     * @brief Validates username and password
+     * @throws LogoutException if invalid
+     */
     void check_logindata();
 
-    // Checks if a Player has a special GM right
+    /**
+     * @brief Checks if player has GM permission
+     * @param right Permission to check
+     * @return True if has permission
+     */
     auto hasGMRight(gm_rights right) const -> bool;
 
-    //! save char to db
+    /**
+     * @brief Saves player to database
+     * @return True if successful
+     */
     auto save() noexcept -> bool;
 
-    //! load data from db
-    // \param no_attributes don't load contents of table "player"
+    /**
+     * @brief Loads player from database
+     * @return True if successful
+     */
     auto load() noexcept -> bool;
 
+    /**
+     * @brief Completes login process and spawns player
+     * @throws LogoutException if no valid spawn position
+     */
     void login();
 
-    // Loads the GM Flag of the character
+    /**
+     * @brief Loads GM flags from database
+     * @return True if successful
+     */
     auto loadGMFlags() noexcept -> bool;
 
+    // Map and screen updates
     /**
-     * sends one area relative to the current z coordinate to the player
-     * @param zoffs the offset of the z param of the area which should be sended
+     * @brief Sends one Z-level area relative to player's position
+     * @param zoffs Z-offset from current position
      */
     void sendRelativeArea(Coordinate zoffs);
 
     /**
-     * sends all areas
+     * @brief Sends complete map (all Z-levels)
      */
     void sendFullMap();
 
     /**
-     * sends one complete mapstripe ( z-2, z-1, z, z+1, z+2) to the client
-     * @param direction the direction from which the whole stripe has to be sent
-     * @param extraStripeForDiagonalMove send an additional stripe for diagonal moves
+     * @brief Sends complete map stripe in direction
+     * @param direction View direction for stripe
+     * @param extraStripeForDiagonalMove Send additional stripe for diagonal movement
      */
     void sendDirStripe(viewdir direction, bool extraStripeForDiagonalMove);
 
+    /**
+     * @brief Sends step stripes after movement
+     * @param dir Movement direction
+     */
     void sendStepStripes(direction dir);
 
+    /**
+     * @brief Sends single field update to client
+     * @param pos Field position
+     */
     void sendField(const position &pos);
 
+    /**
+     * @brief Checks if action is currently running
+     * @return True if action active
+     */
     auto actionRunning() const -> bool override;
 
+    /**
+     * @brief Increases poison value and updates client
+     * @param value Amount to increase
+     */
     void increasePoisonValue(int value) override;
 
+    /**
+     * @brief Gets minimum action points
+     * @return Min AP
+     */
     auto getMinActionPoints() const -> int override;
+
+    /**
+     * @brief Gets maximum action points
+     * @return Max AP
+     */
     auto getMaxActionPoints() const -> int override;
+
+    /**
+     * @brief Gets minimum fight points
+     * @return Min FP
+     */
     auto getMinFightPoints() const -> int override;
+
+    /**
+     * @brief Gets maximum fight points
+     * @return Max FP
+     */
     auto getMaxFightPoints() const -> int override;
 
+    // Showcase (container UI) management
+    /**
+     * @brief Opens container in showcase UI
+     * @param container Container to display
+     * @param item Item representing container
+     * @param carry True if container is carried
+     */
     void openShowcase(Container *container, const ScriptItem &item, bool carry);
+
+    /**
+     * @brief Updates showcase display
+     * @param container Container to update
+     */
     void updateShowcase(Container *container) const;
+
+    /**
+     * @brief Updates single slot in showcase
+     * @param container Container being updated
+     * @param slot Slot index to update
+     */
     void updateShowcaseSlot(Container *container, TYPE_OF_CONTAINERSLOTS slot) const;
+
+    /**
+     * @brief Checks if showcase ID is open
+     * @param showcase Showcase ID
+     * @return True if open
+     */
     auto isShowcaseOpen(uint8_t showcase) const -> bool;
+
+    /**
+     * @brief Checks if container has open showcase
+     * @param container Container to check
+     * @return True if open
+     */
     auto isShowcaseOpen(Container *container) const -> bool;
+
+    /**
+     * @brief Checks if showcase is in inventory
+     * @param showcase Showcase ID
+     * @return True if in inventory (not on ground)
+     */
     auto isShowcaseInInventory(uint8_t showcase) const -> bool;
+
+    /**
+     * @brief Gets showcase ID for container
+     * @param container Container to find
+     * @return Showcase ID (255 if not found)
+     */
     auto getShowcaseId(Container *container) const -> uint8_t;
+
+    /**
+     * @brief Gets container for showcase ID
+     * @param showcase Showcase ID
+     * @return Container pointer (nullptr if not found)
+     */
     auto getShowcaseContainer(uint8_t showcase) const -> Container *;
+
+    /**
+     * @brief Closes showcase by ID
+     * @param showcase Showcase ID
+     */
     void closeShowcase(uint8_t showcase);
+
+    /**
+     * @brief Closes showcase for container
+     * @param container Container to close
+     */
     void closeShowcase(Container *container);
+
+    /**
+     * @brief Closes showcases when player moves
+     */
     void closeOnMove();
+
+    /**
+     * @brief Closes all showcases of ground containers
+     */
     void closeAllShowcasesOfMapContainers();
+
+    /**
+     * @brief Closes all showcases
+     */
     void closeAllShowcases();
+
+    /**
+     * @brief Looks into nested container in showcase
+     * @param showcase Showcase ID
+     * @param pos Slot containing nested container
+     */
     void lookIntoShowcaseContainer(uint8_t showcase, unsigned char pos);
+
+    /**
+     * @brief Looks into backpack
+     * @return True if successful
+     */
     auto lookIntoBackPack() -> bool;
+
+    /**
+     * @brief Looks into container on adjacent field
+     * @param dir Direction to container
+     * @return True if successful
+     */
     auto lookIntoContainerOnField(direction dir) -> bool;
 
+    /**
+     * @brief Changes item quality and updates client
+     * @param pos Item position
+     * @param amount Quality change amount
+     */
     void changeQualityAt(unsigned char pos, int amount) override;
 
+    /**
+     * @brief Checks if this is a monitoring client
+     * @return True if monitoring client
+     */
     inline auto isMonitoringClient() const -> bool { return monitoringClient; }
 
-    //! L�st den Player Magie lernen. Fr standard Charactere keine Funktion in Player berladen
-    //\param type Magierichtung die gelernt werden soll (0 Magier, 1 Priester, 2 Barde, 3 Druide)
-    //\param flag Magieflags die gelernt werden sollen
+    /**
+     * @brief Teaches magic spell to player and updates client
+     * @param type Magic school (0-3)
+     * @param flag Spell flag
+     */
     void teachMagic(unsigned char type, unsigned char flag) override;
 
-    //! Sets the active magic type of a player (druid/mage/...)
-    //\param newMagType Magierichtung, die jetzt aktiv ist (0 Magier, 1 Priester, 2 Barde, 3 Druide)
+    /**
+     * @brief Sets active magic school and updates client
+     * @param newMagType New magic type
+     */
     void setMagicType(magic_type newMagType) override {
         Character::setMagicType(newMagType);
         sendMagicFlags(newMagType);
     }
 
+    /**
+     * @brief Gets localized skill name
+     * @param s Skill ID
+     * @return Skill name in player's language
+     */
     auto getSkillName(TYPE_OF_SKILL_ID s) const -> std::string override;
-    //! Returns the language which the player specified when creating the Character (german/english)
+
+    /**
+     * @brief Gets player's preferred language
+     * @return Language (German or English)
+     */
     auto getPlayerLanguage() const -> Language override;
 
+    /**
+     * @brief Sends all visible characters to client
+     */
     void sendCharacters();
 
-    //! schickt an den Spieler die Daten des Items an
-    // einer Positon des K�pers
-    // \param cpos die Position des Item am K�per
+    /**
+     * @brief Sends equipped item data to client
+     * @param cpos Body position
+     */
     void sendCharacterItemAtPos(unsigned char cpos);
 
     /**
-     *Sends the weather to the client
-     *@weather the weather struct of the weather which is sended
-     *@interior ist the player inside outside?
+     * @brief Sends weather update to client
+     * @param weather Weather data
      */
     void sendWeather(WeatherStruct weather);
 
+    /**
+     * @brief Ages inventory items and updates client
+     */
     void ageInventory() override;
 
+    /**
+     * @brief Creates items and updates client
+     * @param id Item ID
+     * @param number Quantity
+     * @param quality Quality
+     * @param data Script data
+     * @return Amount not created
+     */
     auto createItem(Item::id_type id, Item::number_type number, Item::quality_type quality,
                     script_data_exchangemap const *data) -> int override;
 
+    /**
+     * @brief Processes skill learning
+     * @param skill Skill being trained
+     * @param actionPoints AP cost
+     * @param opponent Difficulty
+     */
     void learn(TYPE_OF_SKILL_ID skill, uint32_t actionPoints, uint8_t opponent) override;
 
+    /**
+     * @brief Increases skill and updates client
+     * @param skill Skill ID
+     * @param amount Amount to increase
+     * @return New skill level
+     */
     auto increaseSkill(TYPE_OF_SKILL_ID skill, int amount) -> int override;
 
+    /**
+     * @brief Deletes all skills and updates client
+     */
     void deleteAllSkills() override;
 
-    //! löscht count Items mit der ID itemid aus dem Inventory des Player
-    // und schickt ein Update an den Spieler
-    // \param itemid die Id der zu löschenden Items
-    // \param count die Anzahl der zu löschenden Items
-    // \oaram data Datawert der zu löschenden Items
-    // \return Anzahl der Items, die nicht gelöscht werden konnten
+    /**
+     * @brief Erases items from inventory and updates client
+     * @param itemid Item ID to erase
+     * @param count Amount to erase
+     * @param data Script data to match
+     * @return Amount not erased
+     */
     auto eraseItem(TYPE_OF_ITEM_ID itemid, int count, script_data_exchangemap const *data = nullptr) -> int override;
 
-    //! ver�dert die Anzahl des Item an der Position pos um count
-    // und schickt ein Update an den Spieler
-    // \param pos die Stelle im Inventory die ge�dert werden soll
-    // \param count die �derungsanzahl
-    // \return der Rest von count, der nicht ge�dert werden konnnte
+    /**
+     * @brief Increases item count at position and updates client
+     * @param pos Item position
+     * @param count Amount to increase
+     * @return Amount not added
+     */
     auto increaseAtPos(unsigned char pos, int count) -> int override;
 
+    /**
+     * @brief Creates items at position and updates client
+     * @param pos Item position
+     * @param newid Item ID
+     * @param count Quantity
+     * @return Amount not created
+     */
     auto createAtPos(unsigned char pos, TYPE_OF_ITEM_ID newid, int count) -> int override;
 
-    //! setzt die Id des Item an der Position pos auf newid
-    // und schickt ein Update an den Spieler
-    // \param pos die Stelle im Inventory die ge�dert werden soll
-    // \param newid die neue Id des Item
-    // \return true falls erfolgreich, false sonst
+    /**
+     * @brief Swaps item at position and updates client
+     * @param pos Item position
+     * @param newid New item ID
+     * @param newQuality New quality
+     * @return True if successful
+     */
     auto swapAtPos(unsigned char pos, TYPE_OF_ITEM_ID newid, int newQuality = 0) -> bool override;
 
-    //! schickt ein Update der Ansicht des Rucksackinhalts an den Client
+    /**
+     * @brief Sends backpack contents update to client
+     */
     void updateBackPackView();
 
-    //! sendet alle Namen der Skills des Player mit den entsprechenden Typen/Werten an den Client
+    /**
+     * @brief Sends all skills to client
+     */
     void sendAllSkills();
 
-    //! sendet Magie-Flags an den Client
-    // \param der Magietyp fr den die Flags an den Client gechickt werden sollen
+    /**
+     * @brief Sends magic flags to client
+     * @param type Magic school
+     */
     void sendMagicFlags(int type);
 
+    /**
+     * @brief Sends single skill update to client
+     * @param skill Skill ID
+     * @param major Major level
+     * @param minor Minor level
+     */
     void sendSkill(TYPE_OF_SKILL_ID skill, int major, int minor);
 
+    /**
+     * @brief Sets skill and updates client
+     * @param skill Skill ID
+     * @param major Major level
+     * @param minor Minor level
+     * @return New major level
+     */
     auto setSkill(TYPE_OF_SKILL_ID skill, int major, int minor) -> int override;
 
+    /**
+     * @brief Saves base attributes to database
+     * @return True if successful
+     */
     auto saveBaseAttributes() -> bool override;
 
-    //! sendet ein Attributupdate an den Client
-    // \param name der Name des Attributs
-    // \param value der Wert des Attributs
+    /**
+     * @brief Sends attribute update to client
+     * @param attribute Attribute to send
+     */
     void sendAttrib(Character::attributeIndex attribute);
 
+    /**
+     * @brief Handles attribute change and updates client
+     * @param attribute Changed attribute
+     */
     void handleAttributeChange(Character::attributeIndex attribute) override;
 
+    /**
+     * @brief Starts music playback
+     * @param title Music track ID
+     */
     void startMusic(short int title) override;
+
+    /**
+     * @brief Resets to default music
+     */
     void defaultMusic() override;
 
+    /**
+     * @brief Sends text file contents to client
+     * @param filename File name
+     * @return True if sent
+     */
     auto sendTextInFile(const std::string &filename) -> bool;
 
-    // Setters and Getters //
+    // Player status management
+    /**
+     * @brief Gets player account status
+     * @return Status code (OK, banned, jailed, etc.)
+     */
     auto getStatus() const -> unsigned char;
+
+    /**
+     * @brief Sets player account status
+     * @param status New status
+     */
     void setStatus(unsigned char status);
 
-    // What time does the status get reset?
+    /**
+     * @brief Gets status expiration time
+     * @return Time when status resets
+     */
     auto getStatusTime() const -> time_t;
+
+    /**
+     * @brief Sets status expiration time
+     * @param time Expiration time
+     */
     void setStatusTime(time_t time);
 
-    // Who banned/jailed the player?
+    /**
+     * @brief Gets GM who banned/jailed player
+     * @return GM name
+     */
     auto getStatusGM() const -> std::string;
+
+    /**
+     * @brief Sets GM who banned/jailed player
+     * @param gm GM character ID
+     */
     void setStatusGM(TYPE_OF_CHARACTER_ID gm);
 
-    // Why where they banned/jailed?
+    /**
+     * @brief Gets ban/jail reason
+     * @return Reason text
+     */
     auto getStatusReason() const -> std::string;
+
+    /**
+     * @brief Sets ban/jail reason
+     * @param reason Reason text
+     */
     void setStatusReason(const std::string &reason);
 
-    // World Map Turtle Graphics
+    // World map turtle graphics
+    /**
+     * @brief Sets turtle graphics mode active
+     * @param tturtleActive True to enable
+     */
     void setTurtleActive(bool tturtleActive);
+
+    /**
+     * @brief Gets turtle graphics mode state
+     * @return True if active
+     */
     auto getTurtleActive() const -> bool;
+
+    /**
+     * @brief Sets turtle tile type
+     * @param tturtletile Tile ID
+     */
     void setTurtleTile(unsigned char tturtletile);
+
+    /**
+     * @brief Gets turtle tile type
+     * @return Tile ID
+     */
     auto getTurtleTile() const -> unsigned char;
 
-    // Clipping on/off (default to on)
+    // Clipping and admin
+    /**
+     * @brief Sets clipping (collision detection) state
+     * @param tclippingActive True to enable
+     */
     void setClippingActive(bool tclippingActive) override;
+
+    /**
+     * @brief Gets clipping state
+     * @return True if enabled
+     */
     auto getClippingActive() const -> bool override;
 
-    // Set for Admin state, uin32_t bit flag
+    /**
+     * @brief Sets admin permission flags
+     * @param tAdmin Bitflags for permissions
+     */
     void setAdmin(uint32_t tAdmin);
+
+    /**
+     * @brief Checks if player has admin rights
+     * @return True if admin
+     */
     auto isAdmin() const -> bool override;
 
+    // Communication
+    /**
+     * @brief Makes player talk and updates all nearby
+     * @param tt Talk type
+     * @param message Message text
+     */
     void talk(talk_type tt, const std::string &message) override;
 
-    // player gets informed about something
+    /**
+     * @brief Informs player with message
+     * @param message Message text
+     * @param type Message type
+     */
     void inform(const std::string &message, informType type = informServer) const override;
+
+    /**
+     * @brief Informs player with language-specific message
+     * @param german German text
+     * @param english English text
+     * @param type Message type
+     */
     void inform(const std::string &german, const std::string &english, informType type = informServer) const override;
 
+    /**
+     * @brief Turns player to face direction
+     * @param dir Direction
+     */
     void turn(direction dir) override;
+
+    /**
+     * @brief Turns player toward position
+     * @param pos Position
+     */
     void turn(const position &pos) override;
 
-    // player heard something
+    /**
+     * @brief Receives text from another character
+     * @param tt Talk type
+     * @param message Message text
+     * @param cc Speaking character
+     */
     void receiveText(talk_type tt, const std::string &message, Character *cc) override;
 
+    // Player knowledge system
+    /**
+     * @brief Checks if player knows another player
+     * @param player Player to check
+     * @return True if knows
+     */
     auto knows(Player *player) const -> bool;
+
+    /**
+     * @brief Adds player to known players
+     * @param player Player to know
+     */
     void getToKnow(Player *player);
+
+    /**
+     * @brief Introduces another player
+     * @param player Player being introduced
+     */
     void introducePlayer(Player *player) override;
+
+    /**
+     * @brief Assigns custom name to player
+     * @param playerId Player ID
+     * @param name Custom name
+     */
     void namePlayer(TYPE_OF_CHARACTER_ID playerId, const std::string &name);
+
+    /**
+     * @brief Gets custom name for player
+     * @param player Player to check
+     * @return Custom name (empty if none)
+     */
     auto getCustomNameOf(Player *player) const -> std::string;
 
+    // Movement
+    /**
+     * @brief Checks if player can move to field
+     * @param field Target field
+     * @return True if movement possible
+     */
     auto moveToPossible(const map::Field &field) const -> bool override;
-    // Move the Player
+
     using Character::move;
+
+    /**
+     * @brief Moves player with specific mode
+     * @param dir Direction
+     * @param mode Movement mode (walk/run)
+     * @return True if successful
+     */
     auto move(direction dir, uint8_t mode) -> bool;
 
+    /**
+     * @brief Checks if player is overtaxed by burden
+     * @return True if overtaxed
+     */
     auto isOvertaxed() -> bool;
 
+    /**
+     * @brief Warps player to position with validation
+     * @param newPos Target position
+     * @return True if successful
+     */
     auto Warp(const position &newPos) -> bool override;
+
+    /**
+     * @brief Forces warp without validation
+     * @param newPos Target position
+     * @return True if successful
+     */
     auto forceWarp(const position &newPos) -> bool override;
 
+    /**
+     * @brief Opens depot container
+     * @param item Depot item
+     */
     void openDepot(const ScriptItem &item);
 
+    // Quest system
+    /**
+     * @brief Sets quest progress and updates client
+     * @param questid Quest ID
+     * @param progress New progress value
+     */
     void setQuestProgress(TYPE_OF_QUEST_ID questid, TYPE_OF_QUESTSTATUS progress) override;
+
+    /**
+     * @brief Sends list of available quests to client
+     */
     void sendAvailableQuests();
+
+    /**
+     * @brief Sends single quest progress to client
+     * @param questId Quest ID
+     * @param progress Progress value
+     */
     void sendQuestProgress(TYPE_OF_QUEST_ID questId, TYPE_OF_QUESTSTATUS progress);
+
+    /**
+     * @brief Sends all quest progress to client
+     */
     void sendCompleteQuestProgress();
+
+    /**
+     * @brief Gets quest progress
+     * @param questid Quest ID
+     * @param time Output: time since update
+     * @return Quest status
+     */
     auto getQuestProgress(TYPE_OF_QUEST_ID questid, int &time) const -> TYPE_OF_QUESTSTATUS override;
 
 private:
+    /**
+     * @brief Handles warp side effects
+     */
     void handleWarp();
 
-    static constexpr auto dialogLimit = 100;
+    static constexpr auto dialogLimit = 100; ///< Maximum concurrent dialogs
 
+    /**
+     * @brief Sends dialog request to client
+     * @tparam DialogType Dialog class type
+     * @tparam DialogCommandType Network command type
+     * @param dialog Dialog to send
+     */
     template <class DialogType, class DialogCommandType> void requestDialog(DialogType *dialog) {
         if (dialog == nullptr) {
             LuaScript::triggerScriptError("Dialog must not be nil!");
@@ -494,6 +1043,12 @@ private:
         }
     }
 
+    /**
+     * @brief Gets dialog by ID
+     * @tparam DialogType Dialog class type
+     * @param dialogId Dialog ID
+     * @return Shared pointer to dialog (nullptr if not found)
+     */
     template <class DialogType> auto getDialog(unsigned int dialogId) const -> std::shared_ptr<DialogType> {
         try {
             return std::dynamic_pointer_cast<DialogType>(dialogs.at(dialogId));
@@ -503,84 +1058,205 @@ private:
     }
 
 public:
+    // Dialog handlers
+    /**
+     * @brief Requests input dialog from player
+     * @param inputDialog Dialog to display
+     */
     void requestInputDialog(InputDialog *inputDialog) override;
+
+    /**
+     * @brief Processes input dialog response
+     * @param dialogId Dialog ID
+     * @param success True if confirmed
+     * @param input User input text
+     */
     void executeInputDialog(unsigned int dialogId, bool success, const std::string &input);
 
+    /**
+     * @brief Requests message dialog
+     * @param messageDialog Dialog to display
+     */
     void requestMessageDialog(MessageDialog *messageDialog) override;
+
+    /**
+     * @brief Processes message dialog close
+     * @param dialogId Dialog ID
+     */
     void executeMessageDialog(unsigned int dialogId);
 
+    /**
+     * @brief Requests merchant trade dialog
+     * @param merchantDialog Dialog to display
+     */
     void requestMerchantDialog(MerchantDialog *merchantDialog) override;
+
+    /**
+     * @brief Handles merchant dialog cancellation
+     * @param dialogId Dialog ID
+     */
     void executeMerchantDialogAbort(unsigned int dialogId);
+
+    /**
+     * @brief Handles merchant buy transaction
+     * @param dialogId Dialog ID
+     * @param index Item index in merchant's list
+     * @param amount Quantity to buy
+     */
     void executeMerchantDialogBuy(unsigned int dialogId, MerchantDialog::index_type index,
                                   Item::number_type amount) const;
+
+    /**
+     * @brief Handles merchant sell transaction
+     * @param dialogId Dialog ID
+     * @param location Item location
+     * @param slot Container slot
+     * @param amount Quantity to sell
+     */
     void executeMerchantDialogSell(unsigned int dialogId, uint8_t location, TYPE_OF_CONTAINERSLOTS slot,
                                    Item::number_type amount);
+
+    /**
+     * @brief Handles merchant item examination
+     * @param dialogId Dialog ID
+     * @param list List type
+     * @param slot Item slot
+     */
     void executeMerchantDialogLookAt(unsigned int dialogId, uint8_t list, uint8_t slot);
 
+    /**
+     * @brief Requests selection dialog
+     * @param selectionDialog Dialog to display
+     */
     void requestSelectionDialog(SelectionDialog *selectionDialog) override;
+
+    /**
+     * @brief Processes selection dialog response
+     * @param dialogId Dialog ID
+     * @param success True if confirmed
+     * @param index Selected index
+     */
     void executeSelectionDialog(unsigned int dialogId, bool success, SelectionDialog::index_type index);
 
+    /**
+     * @brief Requests crafting dialog
+     * @param craftingDialog Dialog to display
+     */
     void requestCraftingDialog(CraftingDialog *craftingDialog) override;
+
+    /**
+     * @brief Handles crafting dialog cancellation
+     * @param dialogId Dialog ID
+     */
     void executeCraftingDialogAbort(unsigned int dialogId);
+
+    /**
+     * @brief Handles crafting request
+     * @param dialogId Dialog ID
+     * @param craftIndex Recipe index
+     * @param craftAmount Quantity to craft
+     */
     void executeCraftingDialogCraft(unsigned int dialogId, uint8_t craftIndex, uint8_t craftAmount);
+
+    /**
+     * @brief Handles crafting completion
+     * @param dialogId Dialog ID
+     */
     void executeCraftingDialogCraftingComplete(unsigned int dialogId);
+
+    /**
+     * @brief Handles crafting abortion
+     * @param dialogId Dialog ID
+     */
     void executeCraftingDialogCraftingAborted(unsigned int dialogId);
+
+    /**
+     * @brief Handles craftable item examination
+     * @param dialogId Dialog ID
+     * @param craftIndex Recipe index
+     */
     void executeCraftingDialogLookAtCraftable(unsigned int dialogId, uint8_t craftIndex);
+
+    /**
+     * @brief Handles crafting ingredient examination
+     * @param dialogId Dialog ID
+     * @param craftIndex Recipe index
+     * @param craftIngredient Ingredient index
+     */
     void executeCraftingDialogLookAtIngredient(unsigned int dialogId, uint8_t craftIndex, uint8_t craftIngredient);
+
+    /**
+     * @brief Provides look-at for crafting result
+     * @param dialogId Dialog ID
+     * @param lookAt Look-at data to populate
+     */
     void requestCraftingLookAt(unsigned int dialogId, ItemLookAt &lookAt) override;
+
+    /**
+     * @brief Provides look-at for crafting ingredient
+     * @param dialogId Dialog ID
+     * @param lookAt Look-at data to populate
+     */
     void requestCraftingLookAtIngredient(unsigned int dialogId, ItemLookAt &lookAt) override;
 
+    /**
+     * @brief Invalidates all open dialogs
+     */
     void invalidateDialogs();
+
+    /**
+     * @brief Closes dialogs when player moves
+     */
     void closeDialogsOnMove();
 
+    /**
+     * @brief Logs admin action
+     * @param message Log message
+     */
     void logAdmin(const std::string &message) override;
 
 private:
+    /**
+     * @brief Starts crafting action sequence
+     * @param stillToCraft Remaining items to craft
+     * @param craftingTime Time per item
+     * @param sfx Sound effect ID
+     * @param sfxDuration Sound duration
+     * @param dialogId Associated dialog ID
+     */
     void startCrafting(uint8_t stillToCraft, uint16_t craftingTime, uint16_t sfx, uint16_t sfxDuration,
                        uint32_t dialogId);
 
-    Language _player_language{};
+    Language _player_language{};          ///< Player's preferred language
+    unsigned char status{};               ///< Account status (OK, banned, jailed, etc.)
+    time_t statustime{};                  ///< Status expiration time
+    TYPE_OF_CHARACTER_ID statusgm{};      ///< GM who set status
+    std::string statusreason;             ///< Status reason text
 
-    // Status of the player, Okay, waiting authroization, jailed, banned, etc..
-    unsigned char status{};
+    bool turtleActive{};                  ///< Turtle graphics mode enabled
+    unsigned char turtletile{};           ///< Turtle tile type
 
-    // What time does the status get reset?
-    time_t statustime{};
+    bool clippingActive = true;           ///< Collision detection enabled
+    uint32_t admin{};                     ///< Admin permission bitflags
+    bool questWriteLock{};                ///< Quest write lock
 
-    // Who banned/jailed the player?
-    TYPE_OF_CHARACTER_ID statusgm{};
+    LoadLevel loadLevel = LoadLevel::unburdened; ///< Current burden level
+    bool monitoringClient{};              ///< Is monitoring client connection
 
-    // Why where they banned/jailed?
-    std::string statusreason;
+    const uint8_t BACKPACK_SHOWCASE = 0;  ///< Backpack showcase ID
+    uint8_t showcaseCounter{};            ///< Next showcase ID
 
-    // World map turtle graphics
-    bool turtleActive{};
-    unsigned char turtletile{};
-
-    // Clipping on/off (default to on)
-    bool clippingActive = true;
-
-    //! gibt an, ob der Spieler erweiterte Rechte hat - are they an admin?
-    uint32_t admin{};
-
-    bool questWriteLock{};
-
-    LoadLevel loadLevel = LoadLevel::unburdened;
-
-    bool monitoringClient{};
-
-    const uint8_t BACKPACK_SHOWCASE = 0;
-    uint8_t showcaseCounter{};
     using ShowcaseMap = std::unordered_map<uint8_t, std::unique_ptr<Showcase>>;
-    ShowcaseMap showcases;
+    ShowcaseMap showcases;                ///< Open container showcases
 
-    unsigned int dialogCounter{};
+    unsigned int dialogCounter{};         ///< Next dialog ID
+
     using DialogMap = std::unordered_map<unsigned int, std::shared_ptr<Dialog>>;
-    DialogMap dialogs;
+    DialogMap dialogs;                    ///< Open dialogs
 
     using QuestStatusTimePair = std::pair<TYPE_OF_QUESTSTATUS, int>;
     using QuestMap = std::unordered_map<TYPE_OF_QUEST_ID, QuestStatusTimePair>;
-    QuestMap quests;
+    QuestMap quests;                      ///< Quest progress tracking
 };
 
 #endif

--- a/src/PlayerManager.hpp
+++ b/src/PlayerManager.hpp
@@ -29,6 +29,12 @@
 
 class Player;
 
+/**
+ * @brief Manages player login, logout, and persistence in separate threads.
+ * 
+ * Singleton that handles asynchronous player connection processing, authentication,
+ * database saves, and graceful disconnection without blocking the main game loop.
+ */
 class PlayerManager {
 public:
     static auto get() -> PlayerManager &;

--- a/src/Random.hpp
+++ b/src/Random.hpp
@@ -24,14 +24,41 @@
 #include <stdexcept>
 #include <type_traits>
 
+/**
+ * @brief Provides thread-safe random number generation using Mersenne Twister.
+ *
+ * This class offers static methods for generating random numbers with uniform
+ * and normal distributions. All methods use a shared Mersenne Twister engine
+ * for high-quality pseudorandom number generation.
+ */
 class Random {
 private:
-    static std::mt19937 rng;
+    static std::mt19937 rng; ///< Mersenne Twister random number generator engine.
 
 public:
+    /**
+     * @brief Generates a uniformly distributed random number in [0.0, 1.0).
+     * @return A random double value between 0.0 (inclusive) and 1.0 (exclusive).
+     * @note Uses std::uniform_real_distribution for high-quality random doubles.
+     */
     static auto uniform() -> double;
+
+    /**
+     * @brief Generates a normally distributed random number.
+     * @param mean The mean (average) of the normal distribution.
+     * @param sd The standard deviation of the normal distribution.
+     * @return A random double value from the specified normal distribution.
+     */
     static auto normal(double mean, double sd) -> double;
 
+    /**
+     * @brief Generates a uniformly distributed random integer in [min, max].
+     * @tparam IntType An integer type (signed or unsigned).
+     * @param min The minimum value (inclusive).
+     * @param max The maximum value (inclusive).
+     * @return A random integer between min and max (both inclusive).
+     * @throws std::invalid_argument if min > max.
+     */
     template <class IntType> static auto uniform(IntType min, IntType max) -> IntType {
         static_assert(std::is_same_v<IntType, short> || std::is_same_v<IntType, int> || std::is_same_v<IntType, long> ||
                       std::is_same_v<IntType, long long> || std::is_same_v<IntType, unsigned short> ||
@@ -47,6 +74,14 @@ public:
         return uniform(rng);
     }
 
+    /**
+     * @brief Generates a uniformly distributed random integer in [0, count-1].
+     * @tparam IntType An unsigned integer type.
+     * @param count The number of possible values (upper bound is count-1).
+     * @return A random integer between 0 (inclusive) and count-1 (inclusive).
+     * @note This is a convenience method for generating array indices or selecting
+     *       from a fixed number of options.
+     */
     template <class IntType> static auto uniform(IntType count) -> IntType {
         static_assert(std::is_unsigned_v<IntType>);
         return uniform(IntType{0}, count - 1);

--- a/src/Scheduler.hpp
+++ b/src/Scheduler.hpp
@@ -26,48 +26,125 @@
 #include <queue>
 #include <string>
 
+/**
+ * @brief Represents a scheduled task that can be executed once or repeatedly.
+ * @tparam clock_type The clock type to use for timing (e.g., std::chrono::steady_clock).
+ *
+ * Tasks can be one-shot (interval of zero) or recurring (positive interval).
+ * Recurring tasks automatically reschedule themselves after execution.
+ */
 template <typename clock_type> class Task {
 public:
+    /**
+     * @brief Constructs a task with specified timing parameters.
+     * @param task The function to execute.
+     * @param start_point The time point when the task should first execute.
+     * @param interval The interval for recurring tasks (zero for one-shot tasks).
+     * @param name A human-readable name for debugging and logging.
+     */
     Task(std::function<void()> task, typename clock_type::time_point start_point, std::chrono::nanoseconds interval,
          std::string name);
 
+    /**
+     * @brief Comparison operator for priority queue ordering (earlier tasks have higher priority).
+     * @param other The other task to compare against.
+     * @return true if this task should execute after the other task.
+     */
     inline auto operator<(const Task &other) const -> bool { return other._next < _next; }
 
+    /**
+     * @brief Executes the task and reschedules if recurring.
+     * @return true if the task should remain in the queue (recurring), false if it should be removed (one-shot).
+     */
     auto run() -> bool;
 
+    /**
+     * @brief Gets the task's name.
+     * @return The task name.
+     */
     [[nodiscard]] inline auto getName() const -> std::string { return _name; }
 
+    /**
+     * @brief Gets the next scheduled execution time.
+     * @return The time point when this task should next execute.
+     */
     [[nodiscard]] inline auto getNextTime() const -> typename clock_type::time_point { return _next; }
 
 private:
-    std::function<void()> _task;
-
-    typename clock_type::time_point _next;
-    std::chrono::nanoseconds _interval;
-    std::string _name;
+    std::function<void()> _task; ///< The function to execute.
+    typename clock_type::time_point _next; ///< The next scheduled execution time.
+    std::chrono::nanoseconds _interval; ///< The interval between executions (zero for one-shot).
+    std::string _name; ///< Human-readable task name for debugging.
 };
 
+/**
+ * @brief A thread-safe task scheduler for executing functions at specific times or intervals.
+ * @tparam clock_type The clock type to use for timing (e.g., std::chrono::steady_clock).
+ *
+ * This scheduler manages a priority queue of tasks and executes them at their scheduled times.
+ * It supports both one-shot and recurring tasks, and can be signaled to wake up for new player actions.
+ */
 template <typename clock_type> class ClockBasedScheduler {
 public:
+    /**
+     * @brief Adds a task that executes once after a delay.
+     * @param task The function to execute.
+     * @param delay The delay before execution.
+     * @param taskname A name for the task (for debugging).
+     */
     void addOneshotTask(std::function<void()> task, std::chrono::nanoseconds delay, const std::string &taskname);
+
+    /**
+     * @brief Adds a task that executes repeatedly at a fixed interval.
+     * @param task The function to execute.
+     * @param interval The time between executions.
+     * @param taskname A name for the task (for debugging).
+     * @param start_immediately If true, execute immediately then repeat; if false, wait one interval before first execution.
+     */
     void addRecurringTask(std::function<void()> task, std::chrono::nanoseconds interval, const std::string &taskname,
                           bool start_immediately = false);
+
+    /**
+     * @brief Adds a recurring task with a specific first execution time.
+     * @param task The function to execute.
+     * @param interval The time between executions.
+     * @param first_time The time point for the first execution.
+     * @param taskname A name for the task (for debugging).
+     */
     void addRecurringTask(std::function<void()> task, std::chrono::nanoseconds interval,
                           typename clock_type::time_point first_time, const std::string &taskname);
+
+    /**
+     * @brief Signals the scheduler that a new player action is available.
+     *
+     * This wakes up the scheduler if it's waiting, allowing it to process player actions immediately.
+     */
     void signalNewPlayerAction();
 
+    /**
+     * @brief Runs the scheduler for one iteration, executing due tasks.
+     * @param max_timeout Maximum time to wait for tasks or signals before returning.
+     */
     void run_once(std::chrono::nanoseconds max_timeout);
 
 private:
+    /**
+     * @brief Gets the time until the next scheduled task.
+     * @return The duration until the next task, or a large value if no tasks are scheduled.
+     */
     auto getNextTaskTime() -> std::chrono::nanoseconds;
+
+    /**
+     * @brief Executes all tasks that are due.
+     */
     void execute_tasks();
 
-    std::mutex _new_action_signal_mutex;
-    std::condition_variable _new_action_available_cond;
+    std::mutex _new_action_signal_mutex; ///< Mutex for the condition variable.
+    std::condition_variable _new_action_available_cond; ///< Condition variable for signaling new actions.
 
-    using task_container_t = std::priority_queue<Task<std::chrono::steady_clock>>;
-    task_container_t _tasks;
-    std::mutex _container_mutex;
+    using task_container_t = std::priority_queue<Task<std::chrono::steady_clock>>; ///< Priority queue type for tasks.
+    task_container_t _tasks; ///< The queue of scheduled tasks.
+    std::mutex _container_mutex; ///< Mutex protecting the task queue.
 };
 
 #include "Scheduler.tcc"

--- a/src/Showcase.hpp
+++ b/src/Showcase.hpp
@@ -21,6 +21,12 @@
 
 class Container;
 
+/**
+ * @brief Represents an open container view for a player.
+ * 
+ * Tracks whether a container is being viewed in the player's inventory or
+ * on the ground, enabling proper container state management.
+ */
 class Showcase {
 public:
     Showcase(Container *container, bool carry);

--- a/src/SpawnPoint.hpp
+++ b/src/SpawnPoint.hpp
@@ -28,60 +28,107 @@
 // just declare a class named World...
 class World;
 
-//! defines a Spawnpoint
+/**
+ * @brief Manages automatic spawning of monsters at a specific location.
+ *
+ * A SpawnPoint tracks multiple monster types and their spawn counts, automatically
+ * creating new monsters at regular intervals when they die or when spawn time elapses.
+ * Monsters can spawn within a defined range and have movement restrictions.
+ */
 class SpawnPoint {
 public:
-    //! Creates a new SpawnPoint at <pos>
+    /**
+     * @brief Creates a new SpawnPoint at the specified position.
+     * @param pos The center position for this spawn point.
+     * @param Range Maximum walking distance from spawn position for spawned monsters.
+     * @param Spawnrange Radius around spawn position where monsters can initially appear.
+     * @param Min_Spawntime Minimum cycles before attempting a new spawn.
+     * @param Max_Spawntime Maximum cycles before attempting a new spawn.
+     * @param Spawnall If true, spawn all missing monsters each cycle; if false, spawn random subset.
+     */
     explicit SpawnPoint(const position &pos, Coordinate Range = defaultWalkRange, Coordinate Spawnrange = 0,
                         uint16_t Min_Spawntime = 1, uint16_t Max_Spawntime = 1, bool Spawnall = false);
 
+    /**
+     * @brief Adds a monster type to this spawn point.
+     * @param type The monster type ID to spawn.
+     * @param count The maximum number of this monster type to maintain.
+     * @note If the type already exists, the count is added to the existing maximum.
+     */
     void addMonster(TYPE_OF_CHARACTER_ID type, int count);
 
-    //! load spawnpoints from database
+    /**
+     * @brief Loads spawn point configuration from the database.
+     * @param id The database ID of the spawn point to load.
+     * @return true if loaded successfully, false otherwise.
+     */
     auto load(const int &id) -> bool;
 
+    /**
+     * @brief Attempts to spawn monsters if spawn time has elapsed.
+     * @note Spawning only occurs if world spawning is enabled and spawn timer reaches zero.
+     */
     void spawn();
 
-    //! callback called by dying monsters belonging to spawnpoint
+    /**
+     * @brief Callback invoked when a monster belonging to this spawn point dies.
+     * @param type The monster type ID that died.
+     * @note Decrements the active count for that monster type.
+     */
     void dead(TYPE_OF_CHARACTER_ID type);
 
+    /**
+     * @brief Gets the X coordinate of the spawn position.
+     * @return The X coordinate.
+     */
     [[nodiscard]] inline auto get_x() const -> Coordinate { return spawnpos.x; }
+
+    /**
+     * @brief Gets the Y coordinate of the spawn position.
+     * @return The Y coordinate.
+     */
     [[nodiscard]] inline auto get_y() const -> Coordinate { return spawnpos.y; }
+
+    /**
+     * @brief Gets the Z coordinate of the spawn position.
+     * @return The Z coordinate.
+     */
     [[nodiscard]] inline auto get_z() const -> Coordinate { return spawnpos.z; }
 
+    /**
+     * @brief Gets the maximum walking range for spawned monsters.
+     * @return The walking range in map coordinates.
+     */
     [[nodiscard]] inline auto getRange() const -> Coordinate { return range; }
 
 private:
-    // our link to the world...
-    World *world;
+    World *world; ///< Link to the game world.
 
-    position spawnpos;
+    position spawnpos; ///< Center position of the spawn point.
 
-    // walkrange of the monsters from the spawn
-    Coordinate range;
+    Coordinate range; ///< Maximum walking distance from spawn for spawned monsters.
 
-    // range of the spawns, in this area the creatures can be spawned
-    Coordinate spawnrange;
+    Coordinate spawnrange; ///< Radius around spawn position where monsters can initially appear.
 
-    // the number of cycles untlin new monsters are spawned
-    uint16_t min_spawntime;
-    uint16_t max_spawntime;
+    uint16_t min_spawntime; ///< Minimum cycles before spawning.
+    uint16_t max_spawntime; ///< Maximum cycles before spawning.
 
-    // the number of cycles until the next spawn
-    uint16_t nextspawntime;
+    uint16_t nextspawntime; ///< Cycles remaining until next spawn attempt.
 
-    // should be all monsters respawned in every cycle
-    bool spawnall;
+    bool spawnall; ///< If true, spawn all missing monsters; if false, spawn random subset.
 
+    /**
+     * @brief Tracks spawn information for a single monster type.
+     */
     struct SpawnEntryStruct {
-        TYPE_OF_CHARACTER_ID typ;
-        int max_count;
-        int akt_count;
+        TYPE_OF_CHARACTER_ID typ; ///< Monster type ID.
+        int max_count; ///< Maximum number of this monster type to maintain.
+        int akt_count; ///< Current number of active monsters of this type.
     };
 
-    std::list<struct SpawnEntryStruct> SpawnTypes;
+    std::list<struct SpawnEntryStruct> SpawnTypes; ///< List of monster types managed by this spawn point.
 
-    static constexpr Coordinate defaultWalkRange = 20;
+    static constexpr Coordinate defaultWalkRange = 20; ///< Default walking range for monsters.
 };
 
 #endif

--- a/src/TableStructs.hpp
+++ b/src/TableStructs.hpp
@@ -32,151 +32,209 @@ class LuaMonsterScript;
 class LuaWeaponScript;
 class LuaLongTimeEffectScript;
 
+/**
+ * @brief Contains all properties and metadata for an item type.
+ *
+ * This structure defines the characteristics of an item including physical properties,
+ * value, aging behavior, and localized names/descriptions.
+ */
 struct ItemStruct {
-    TYPE_OF_ITEM_ID id = 0;
-    TYPE_OF_VOLUME Volume = 0;
-    TYPE_OF_WEIGHT Weight = 0;
-    TYPE_OF_AGINGSPEED AgeingSpeed = 0;
-    TYPE_OF_ITEM_ID ObjectAfterRot = 0;
-    TYPE_OF_ITEM_ID AfterInfiniteRot = 0;
-    TYPE_OF_BRIGHTNESS Brightness = 0;
-    TYPE_OF_WORTH Worth = 0;
-    TYPE_OF_MAX_STACK MaxStack = 1;
-    TYPE_OF_BUY_STACK BuyStack = 1;
-    bool rotsInInventory = false;
-    TYPE_OF_ENGLISH serverName;
-    TYPE_OF_ENGLISH English;
-    TYPE_OF_GERMAN German;
-    TYPE_OF_ENGLISH EnglishDescription;
-    TYPE_OF_GERMAN GermanDescription;
-    int16_t Rareness = 1;
-    TYPE_OF_ITEMLEVEL Level = 0;
+    TYPE_OF_ITEM_ID id = 0;               ///< Unique item type identifier.
+    TYPE_OF_VOLUME Volume = 0;            ///< Volume/size of the item.
+    TYPE_OF_WEIGHT Weight = 0;            ///< Weight of the item.
+    TYPE_OF_AGINGSPEED AgeingSpeed = 0;   ///< How quickly the item ages/decays.
+    TYPE_OF_ITEM_ID ObjectAfterRot = 0;   ///< Item ID this becomes after aging once.
+    TYPE_OF_ITEM_ID AfterInfiniteRot = 0; ///< Item ID this becomes after complete decay.
+    TYPE_OF_BRIGHTNESS Brightness = 0;    ///< Light level emitted by this item.
+    TYPE_OF_WORTH Worth = 0;              ///< Base monetary value.
+    TYPE_OF_MAX_STACK MaxStack = 1;       ///< Maximum items that can stack together.
+    TYPE_OF_BUY_STACK BuyStack = 1;       ///< Default purchase stack size.
+    bool rotsInInventory = false;         ///< Whether item ages while in inventory.
+    TYPE_OF_ENGLISH serverName;           ///< Internal server name.
+    TYPE_OF_ENGLISH English;              ///< English display name.
+    TYPE_OF_GERMAN German;                ///< German display name.
+    TYPE_OF_ENGLISH EnglishDescription;   ///< English description text.
+    TYPE_OF_GERMAN GermanDescription;     ///< German description text.
+    int16_t Rareness = 1;                 ///< Rarity level of the item.
+    TYPE_OF_ITEMLEVEL Level = 0;          ///< Required level to use this item.
 
+    /**
+     * @brief Checks if this item struct contains valid data.
+     * @return true if id is non-zero, false otherwise.
+     */
     [[nodiscard]] inline auto isValid() const -> bool { return id != 0; }
 };
 
+/**
+ * @brief Tile modification parameters.
+ */
 struct TilesModificatorStruct {
-    unsigned char Modificator;
+    unsigned char Modificator; ///< Modification value for tile properties.
 };
 
+/**
+ * @brief Defines a long-term effect that can be applied to characters.
+ */
 struct LongTimeEffectStruct {
-    uint16_t effectid = 0;
-    std::string effectname;
-    std::string scriptname;
-    std::shared_ptr<LuaLongTimeEffectScript> script;
+    uint16_t effectid = 0;                           ///< Unique effect identifier.
+    std::string effectname;                          ///< Human-readable effect name.
+    std::string scriptname;                          ///< Script file name for this effect.
+    std::shared_ptr<LuaLongTimeEffectScript> script; ///< Loaded script instance.
 };
 
+/**
+ * @brief Contains weapon properties and combat statistics.
+ *
+ * Defines weapon types, damage characteristics, and combat mechanics.
+ */
 struct WeaponStruct {
-    static constexpr auto slashing = 1;
-    static constexpr auto concussion = 2;
-    static constexpr auto puncture = 3;
-    static constexpr auto slashingTwoHand = 4;
-    static constexpr auto concussionTwoHand = 5;
-    static constexpr auto punctureTwoHand = 6;
-    static constexpr auto firearm = 7;
-    static constexpr auto arrow = 10;
-    static constexpr auto bolt = 11;
-    static constexpr auto stone = 12;
-    static constexpr auto stave = 13;
-    static constexpr auto shield = 14;
-    TYPE_OF_ATTACK Attack{0};
-    TYPE_OF_DEFENCE Defence{0};
-    TYPE_OF_ACCURACY Accuracy{0};
-    TYPE_OF_RANGE Range{0};
-    TYPE_OF_WEAPONTYPE Type{0};
-    TYPE_OF_AMMUNITIONTYPE AmmunitionType{0};
-    TYPE_OF_ACTIONPOINTS ActionPoints{0};
-    TYPE_OF_MAGICDISTURBANCE MagicDisturbance{0};
-    TYPE_OF_POISONSTRENGTH PoisonStrength{0};
+    static constexpr auto slashing = 1;          ///< One-handed slashing weapon.
+    static constexpr auto concussion = 2;        ///< One-handed bludgeoning weapon.
+    static constexpr auto puncture = 3;          ///< One-handed piercing weapon.
+    static constexpr auto slashingTwoHand = 4;   ///< Two-handed slashing weapon.
+    static constexpr auto concussionTwoHand = 5; ///< Two-handed bludgeoning weapon.
+    static constexpr auto punctureTwoHand = 6;   ///< Two-handed piercing weapon.
+    static constexpr auto firearm = 7;           ///< Ranged firearm.
+    static constexpr auto arrow = 10;            ///< Arrow ammunition.
+    static constexpr auto bolt = 11;             ///< Crossbow bolt ammunition.
+    static constexpr auto stone = 12;            ///< Stone/thrown weapon.
+    static constexpr auto stave = 13;            ///< Two-handed stave.
+    static constexpr auto shield = 14;           ///< Shield (defensive weapon).
+
+    TYPE_OF_ATTACK Attack{0};                     ///< Base attack value.
+    TYPE_OF_DEFENCE Defence{0};                   ///< Base defence value.
+    TYPE_OF_ACCURACY Accuracy{0};                 ///< Accuracy/hit chance modifier.
+    TYPE_OF_RANGE Range{0};                       ///< Attack range.
+    TYPE_OF_WEAPONTYPE Type{0};                   ///< Weapon type constant.
+    TYPE_OF_AMMUNITIONTYPE AmmunitionType{0};     ///< Required ammunition type for ranged weapons.
+    TYPE_OF_ACTIONPOINTS ActionPoints{0};         ///< Action points required to use.
+    TYPE_OF_MAGICDISTURBANCE MagicDisturbance{0}; ///< Magic casting penalty.
+    TYPE_OF_POISONSTRENGTH PoisonStrength{0};     ///< Poison damage on hit.
+
     WeaponStruct() = default;
 
+    /**
+     * @brief Checks if this weapon requires two hands to wield.
+     * @return true if the weapon is two-handed, false otherwise.
+     */
     [[nodiscard]] inline auto isTwoHanded() const -> bool {
         return Type == slashingTwoHand || Type == concussionTwoHand || Type == punctureTwoHand || Type == stave;
     };
 };
 
+/**
+ * @brief Contains armor properties and protection statistics.
+ *
+ * Defines armor types, body coverage, and damage resistance values.
+ */
 struct ArmorStruct {
-    static constexpr auto clothing = 0;
-    static constexpr auto general = 1;
-    static constexpr auto light = 2;
-    static constexpr auto medium = 3;
-    static constexpr auto heavy = 4;
-    static constexpr auto juwellery = 5;
-    TYPE_OF_BODYPARTS BodyParts{0};
-    TYPE_OF_PUNCTUREARMOR PunctureArmor{0};
-    TYPE_OF_STROKEARMOR StrokeArmor{0};
-    TYPE_OF_THRUSTARMOR ThrustArmor{0};
-    TYPE_OF_MAGICDISTURBANCE MagicDisturbance{0};
-    int16_t Absorb{0};
-    int16_t Stiffness{0};
-    TYPE_OF_ARMORTYPE Type{0};
+    static constexpr auto clothing = 0;  ///< Clothing (no armor).
+    static constexpr auto general = 1;   ///< General/untyped armor.
+    static constexpr auto light = 2;     ///< Light armor.
+    static constexpr auto medium = 3;    ///< Medium armor.
+    static constexpr auto heavy = 4;     ///< Heavy armor.
+    static constexpr auto juwellery = 5; ///< Jewelry (accessories).
+
+    TYPE_OF_BODYPARTS BodyParts{0};               ///< Body parts covered by this armor.
+    TYPE_OF_PUNCTUREARMOR PunctureArmor{0};       ///< Protection against piercing damage.
+    TYPE_OF_STROKEARMOR StrokeArmor{0};           ///< Protection against slashing damage.
+    TYPE_OF_THRUSTARMOR ThrustArmor{0};           ///< Protection against bludgeoning damage.
+    TYPE_OF_MAGICDISTURBANCE MagicDisturbance{0}; ///< Magic casting penalty.
+    int16_t Absorb{0};                            ///< Damage absorption value.
+    int16_t Stiffness{0};                         ///< Movement penalty/stiffness.
+    TYPE_OF_ARMORTYPE Type{0};                    ///< Armor type constant.
+
     ArmorStruct() = default;
 };
 
+/**
+ * @brief Defines a character skill with localized names.
+ */
 struct SkillStruct {
-    std::string serverName;
-    TYPE_OF_ENGLISH englishName;
-    TYPE_OF_GERMAN germanName;
+    std::string serverName;      ///< Internal server name for the skill.
+    TYPE_OF_ENGLISH englishName; ///< English display name.
+    TYPE_OF_GERMAN germanName;   ///< German display name.
 };
 
+/**
+ * @brief Contains tile/terrain properties.
+ */
 struct TilesStruct {
-    unsigned char flags{};
-    TYPE_OF_WALKINGCOST walkingCost{};
-    TYPE_OF_GERMAN German;
-    TYPE_OF_ENGLISH English;
+    unsigned char flags{};             ///< Tile behavior flags.
+    TYPE_OF_WALKINGCOST walkingCost{}; ///< Movement cost to traverse this tile.
+    TYPE_OF_GERMAN German;             ///< German name for the tile.
+    TYPE_OF_ENGLISH English;           ///< English name for the tile.
 };
 
+/**
+ * @brief Defines player race creation parameters and attribute limits.
+ */
 struct PlayerraceStruct {
-    std::string racename;
-    short int points;
-    short int minage;
-    short int maxage;
-    short int minweight;
-    short int maxweight;
-    unsigned char minbodyheight;
-    unsigned char maxbodyheight;
-    unsigned char minagility;
-    unsigned char maxagility;
-    unsigned char minconstitution;
-    unsigned char maxconstitution;
-    unsigned char mindexterity;
-    unsigned char maxdexterity;
-    unsigned char minessence;
-    unsigned char maxessence;
-    unsigned char minintelligence;
-    unsigned char maxintelligence;
-    unsigned char minperception;
-    unsigned char maxperception;
-    unsigned char minstrength;
-    unsigned char maxstrength;
-    unsigned char minwillpower;
-    unsigned char maxwillpower;
+    std::string racename;          ///< Race name.
+    short int points;              ///< Starting attribute points.
+    short int minage;              ///< Minimum starting age.
+    short int maxage;              ///< Maximum starting age.
+    short int minweight;           ///< Minimum character weight.
+    short int maxweight;           ///< Maximum character weight.
+    unsigned char minbodyheight;   ///< Minimum body height.
+    unsigned char maxbodyheight;   ///< Maximum body height.
+    unsigned char minagility;      ///< Minimum agility value.
+    unsigned char maxagility;      ///< Maximum agility value.
+    unsigned char minconstitution; ///< Minimum constitution value.
+    unsigned char maxconstitution; ///< Maximum constitution value.
+    unsigned char mindexterity;    ///< Minimum dexterity value.
+    unsigned char maxdexterity;    ///< Maximum dexterity value.
+    unsigned char minessence;      ///< Minimum essence value.
+    unsigned char maxessence;      ///< Maximum essence value.
+    unsigned char minintelligence; ///< Minimum intelligence value.
+    unsigned char maxintelligence; ///< Maximum intelligence value.
+    unsigned char minperception;   ///< Minimum perception value.
+    unsigned char maxperception;   ///< Maximum perception value.
+    unsigned char minstrength;     ///< Minimum strength value.
+    unsigned char maxstrength;     ///< Maximum strength value.
+    unsigned char minwillpower;    ///< Minimum willpower value.
+    unsigned char maxwillpower;    ///< Maximum willpower value.
 };
 
+/**
+ * @brief Monster armor values for different damage types.
+ */
 struct MonsterArmor {
-    short int strokeArmor{0};
-    short int punctureArmor{0};
-    short int thrustArmor{0};
+    short int strokeArmor{0};   ///< Protection against slashing damage.
+    short int punctureArmor{0}; ///< Protection against piercing damage.
+    short int thrustArmor{0};   ///< Protection against bludgeoning damage.
+
     MonsterArmor() = default;
 };
 
+/**
+ * @brief Defines an item with quantity and aging for inventory/equipment.
+ */
 struct itemdef_t {
-    TYPE_OF_ITEM_ID itemid{};
-    std::pair<unsigned short, unsigned short> amount;
-    TYPE_OF_AGINGSPEED AgeingSpeed{};
+    TYPE_OF_ITEM_ID itemid{};                         ///< Item type ID.
+    std::pair<unsigned short, unsigned short> amount; ///< Min and max quantity range.
+    TYPE_OF_AGINGSPEED AgeingSpeed{};                 ///< Aging speed for this item instance.
 };
 
+/**
+ * @brief Character attribute ranges for generation or configuration.
+ *
+ * Each attribute is represented as a pair (min, max) for random generation.
+ */
 struct attributedef_t {
-    std::pair<unsigned short, unsigned short> luck;
-    std::pair<unsigned short, unsigned short> strength;
-    std::pair<unsigned short, unsigned short> dexterity;
-    std::pair<unsigned short, unsigned short> constitution;
-    std::pair<unsigned short, unsigned short> agility;
-    std::pair<unsigned short, unsigned short> intelligence;
-    std::pair<unsigned short, unsigned short> perception;
-    std::pair<unsigned short, unsigned short> willpower;
-    std::pair<unsigned short, unsigned short> essence;
+    std::pair<unsigned short, unsigned short> luck;         ///< Luck attribute range.
+    std::pair<unsigned short, unsigned short> strength;     ///< Strength attribute range.
+    std::pair<unsigned short, unsigned short> dexterity;    ///< Dexterity attribute range.
+    std::pair<unsigned short, unsigned short> constitution; ///< Constitution attribute range.
+    std::pair<unsigned short, unsigned short> agility;      ///< Agility attribute range.
+    std::pair<unsigned short, unsigned short> intelligence; ///< Intelligence attribute range.
+    std::pair<unsigned short, unsigned short> perception;   ///< Perception attribute range.
+    std::pair<unsigned short, unsigned short> willpower;    ///< Willpower attribute range.
+    std::pair<unsigned short, unsigned short> essence;      ///< Essence attribute range.
 
+    /**
+     * @brief Constructs attribute definition with default values.
+     */
     attributedef_t()
             : luck(std::make_pair(defaultLuck, defaultLuck)),
               strength(std::make_pair(defaultStrength, defaultStrength)),
@@ -189,81 +247,95 @@ struct attributedef_t {
               essence(std::make_pair(defaultEssence, defaultEssence)) {}
 
 private:
-    static constexpr uint16_t defaultLuck = 10;
-    static constexpr uint16_t defaultStrength = 15;
-    static constexpr uint16_t defaultDexterity = 10;
-    static constexpr uint16_t defaultConstitution = 8;
-    static constexpr uint16_t defaultAgility = 10;
-    static constexpr uint16_t defaultIntelligence = 10;
-    static constexpr uint16_t defaultPerception = 10;
-    static constexpr uint16_t defaultWillpower = 10;
-    static constexpr uint16_t defaultEssence = 10;
+    static constexpr uint16_t defaultLuck = 10;         ///< Default luck value.
+    static constexpr uint16_t defaultStrength = 15;     ///< Default strength value.
+    static constexpr uint16_t defaultDexterity = 10;    ///< Default dexterity value.
+    static constexpr uint16_t defaultConstitution = 8;  ///< Default constitution value.
+    static constexpr uint16_t defaultAgility = 10;      ///< Default agility value.
+    static constexpr uint16_t defaultIntelligence = 10; ///< Default intelligence value.
+    static constexpr uint16_t defaultPerception = 10;   ///< Default perception value.
+    static constexpr uint16_t defaultWillpower = 10;    ///< Default willpower value.
+    static constexpr uint16_t defaultEssence = 10;      ///< Default essence value.
 };
 
+/**
+ * @brief Complete monster definition including stats, loot, and behavior.
+ */
 struct MonsterStruct {
+    /**
+     * @brief Defines an item that can drop as loot with probability and variance.
+     */
     struct LootStruct {
-        TYPE_OF_ITEM_ID itemId{};
-        double probability{};
-        std::pair<uint16_t, uint16_t> amount;
-        std::pair<uint16_t, uint16_t> quality;
-        std::pair<uint16_t, uint16_t> durability;
-        std::map<std::string, std::string> data;
+        TYPE_OF_ITEM_ID itemId{};                 ///< Item type that can drop.
+        double probability{};                     ///< Drop chance (0.0 to 1.0).
+        std::pair<uint16_t, uint16_t> amount;     ///< Min and max quantity range.
+        std::pair<uint16_t, uint16_t> quality;    ///< Min and max quality range.
+        std::pair<uint16_t, uint16_t> durability; ///< Min and max durability range.
+        std::map<std::string, std::string> data;  ///< Additional item data key-value pairs.
     };
 
-    using skilltype = std::map<TYPE_OF_SKILL_ID, std::pair<unsigned short, unsigned short>>;
-    using itemtype = std::map<unsigned short, std::vector<itemdef_t>>;
-    using loottype = std::map<uint16_t, std::map<uint16_t, LootStruct>>;
-    std::string nameDe;
-    std::string nameEn;
-    TYPE_OF_RACE_ID race{};
-    unsigned short hitpoints{};
-    bool canselfheal{};
-    movement_type movement{};
-    bool canattack{};
-    attributedef_t attributes;
-    skilltype skills;
-    itemtype items;
-    loottype loot;
-    std::shared_ptr<LuaMonsterScript> script;
-    uint16_t minsize{};
-    uint16_t maxsize{};
+    using skilltype =
+            std::map<TYPE_OF_SKILL_ID, std::pair<unsigned short, unsigned short>>; ///< Skill map with min/max values.
+    using itemtype = std::map<unsigned short, std::vector<itemdef_t>>;   ///< Equipment slots mapped to possible items.
+    using loottype = std::map<uint16_t, std::map<uint16_t, LootStruct>>; ///< Categorized loot tables.
+
+    std::string nameDe;                       ///< German monster name.
+    std::string nameEn;                       ///< English monster name.
+    TYPE_OF_RACE_ID race{};                   ///< Monster race identifier.
+    unsigned short hitpoints{};               ///< Maximum hit points.
+    bool canselfheal{};                       ///< Whether monster can regenerate health.
+    movement_type movement{};                 ///< Movement type (walk/fly/crawl).
+    bool canattack{};                         ///< Whether monster can initiate combat.
+    attributedef_t attributes;                ///< Monster attribute ranges.
+    skilltype skills;                         ///< Monster skill ranges.
+    itemtype items;                           ///< Starting equipment by slot.
+    loottype loot;                            ///< Loot drop tables.
+    std::shared_ptr<LuaMonsterScript> script; ///< AI/behavior script.
+    uint16_t minsize{};                       ///< Minimum monster size.
+    uint16_t maxsize{};                       ///< Maximum monster size.
 };
 
+/**
+ * @brief Race-specific constraints and defaults for character creation.
+ */
 struct RaceStruct {
-    std::string serverName;
-    uint16_t minSize = defaultMinHeight;
-    uint16_t maxSize = defaultMaxHeight;
-    uint8_t minAgility = defaultMinAttribute;
-    uint8_t maxAgility = defaultMaxAttribute;
-    uint8_t minConstitution = defaultMinAttribute;
-    uint8_t maxConstitution = defaultMaxAttribute;
-    uint8_t minDexterity = defaultMinAttribute;
-    uint8_t maxDexterity = defaultMaxAttribute;
-    uint8_t minEssence = defaultMinAttribute;
-    uint8_t maxEssence = defaultMaxAttribute;
-    uint8_t minIntelligence = defaultMinAttribute;
-    uint8_t maxIntelligence = defaultMaxAttribute;
-    uint8_t minPerception = defaultMinAttribute;
-    uint8_t maxPerception = defaultMaxAttribute;
-    uint8_t minStrength = defaultMinAttribute;
-    uint8_t maxStrength = defaultMaxAttribute;
-    uint8_t minWillpower = defaultMinAttribute;
-    uint8_t maxWillpower = defaultMaxAttribute;
-    uint8_t maxAttribs = defaultMaxAttributePoints;
+    std::string serverName;                         ///< Internal race identifier.
+    uint16_t minSize = defaultMinHeight;            ///< Minimum character height.
+    uint16_t maxSize = defaultMaxHeight;            ///< Maximum character height.
+    uint8_t minAgility = defaultMinAttribute;       ///< Minimum agility attribute.
+    uint8_t maxAgility = defaultMaxAttribute;       ///< Maximum agility attribute.
+    uint8_t minConstitution = defaultMinAttribute;  ///< Minimum constitution attribute.
+    uint8_t maxConstitution = defaultMaxAttribute;  ///< Maximum constitution attribute.
+    uint8_t minDexterity = defaultMinAttribute;     ///< Minimum dexterity attribute.
+    uint8_t maxDexterity = defaultMaxAttribute;     ///< Maximum dexterity attribute.
+    uint8_t minEssence = defaultMinAttribute;       ///< Minimum essence attribute.
+    uint8_t maxEssence = defaultMaxAttribute;       ///< Maximum essence attribute.
+    uint8_t minIntelligence = defaultMinAttribute;  ///< Minimum intelligence attribute.
+    uint8_t maxIntelligence = defaultMaxAttribute;  ///< Maximum intelligence attribute.
+    uint8_t minPerception = defaultMinAttribute;    ///< Minimum perception attribute.
+    uint8_t maxPerception = defaultMaxAttribute;    ///< Maximum perception attribute.
+    uint8_t minStrength = defaultMinAttribute;      ///< Minimum strength attribute.
+    uint8_t maxStrength = defaultMaxAttribute;      ///< Maximum strength attribute.
+    uint8_t minWillpower = defaultMinAttribute;     ///< Minimum willpower attribute.
+    uint8_t maxWillpower = defaultMaxAttribute;     ///< Maximum willpower attribute.
+    uint8_t maxAttribs = defaultMaxAttributePoints; ///< Total attribute points allowed.
 
-    static constexpr uint16_t defaultMinHeight = 100;
-    static constexpr uint16_t defaultMaxHeight = 100;
-    static constexpr uint8_t defaultMinAttribute = 2;
-    static constexpr uint8_t defaultMaxAttribute = 20;
-    static constexpr uint8_t defaultMaxAttributePoints = 84;
+    static constexpr uint16_t defaultMinHeight = 100;        ///< Default minimum height.
+    static constexpr uint16_t defaultMaxHeight = 100;        ///< Default maximum height.
+    static constexpr uint8_t defaultMinAttribute = 2;        ///< Default minimum attribute value.
+    static constexpr uint8_t defaultMaxAttribute = 20;       ///< Default maximum attribute value.
+    static constexpr uint8_t defaultMaxAttributePoints = 84; ///< Default total attribute points.
 };
 
+/**
+ * @brief Character appearance configuration for a specific race.
+ */
 struct RaceConfiguration {
-    uint32_t subType = 0;
-    uint16_t hair = 0;
-    uint16_t beard = 0;
-    Colour hairColour;
-    Colour skinColour;
+    uint32_t subType = 0; ///< Race subtype/variant identifier.
+    uint16_t hair = 0;    ///< Hair style identifier.
+    uint16_t beard = 0;   ///< Beard style identifier.
+    Colour hairColour;    ///< Hair color.
+    Colour skinColour;    ///< Skin color.
 };
 
 #endif

--- a/src/Timer.hpp
+++ b/src/Timer.hpp
@@ -21,18 +21,39 @@
 
 #include <chrono>
 
+/**
+ * @brief A simple interval timer for periodic event checking.
+ *
+ * This timer uses std::chrono::steady_clock to track time intervals and
+ * determine when a specified duration has elapsed. Useful for implementing
+ * periodic updates, cooldowns, or rate limiting.
+ */
 class Timer {
 public:
-    using clock = std::chrono::steady_clock;
-    using timePoint = clock::time_point;
-    using duration = clock::duration;
+    using clock = std::chrono::steady_clock; ///< The clock type used for timing.
+    using timePoint = clock::time_point; ///< A point in time from the steady clock.
+    using duration = clock::duration; ///< A time duration type.
 
+    /**
+     * @brief Constructs a timer with the specified interval.
+     * @param interval The duration to wait between intervals.
+     * @note The timer is initialized with the current time as the starting point.
+     */
     explicit Timer(duration interval);
+
+    /**
+     * @brief Checks if the interval has been exceeded since the last check.
+     *
+     * When this method returns true, it resets the internal timer to the current
+     * time, starting a new interval period.
+     *
+     * @return true if the interval duration has elapsed, false otherwise.
+     */
     auto intervalExceeded() -> bool;
 
 private:
-    timePoint lastIntervalExceeded;
-    duration interval;
+    timePoint lastIntervalExceeded; ///< Timestamp when the interval was last exceeded.
+    duration interval; ///< The duration of the interval to check against.
 };
 
 #endif

--- a/src/WaypointList.hpp
+++ b/src/WaypointList.hpp
@@ -26,21 +26,68 @@
 
 class Character;
 
+/**
+ * @brief Manages a list of waypoints for character pathfinding and movement.
+ *
+ * This class maintains a queue of positions that a character should navigate to,
+ * and calculates step-by-step movement directions to reach each waypoint in sequence.
+ */
 class WaypointList {
 public:
-    static const uint8_t max_fields_for_waypoints = 12;
+    static const uint8_t max_fields_for_waypoints = 12; ///< Maximum distance for pathfinding calculations.
+
+    /**
+     * @brief Constructs a waypoint list for a specific character.
+     * @param movechar The character that will follow these waypoints.
+     */
     explicit WaypointList(Character *movechar);
+
+    /**
+     * @brief Gets the list of waypoints.
+     * @return A const reference to the list of positions.
+     */
     [[nodiscard]] auto getWaypoints() const -> const std::list<position> &;
+
+    /**
+     * @brief Adds a waypoint to the end of the list.
+     * @param pos The position to add as a waypoint.
+     */
     void addWaypoint(const position &pos);
+
+    /**
+     * @brief Gets the next waypoint without removing it from the list.
+     * @param pos Output parameter to receive the next waypoint position.
+     * @return true if a waypoint exists, false if the list is empty.
+     */
     auto getNextWaypoint(position &pos) const -> bool;
+
+    /**
+     * @brief Clears all waypoints from the list.
+     */
     void clear();
+
+    /**
+     * @brief Executes one movement step toward the next waypoint.
+     * @return true if a move was made, false if no more waypoints or movement failed.
+     */
     auto makeMove() -> bool;
+
+    /**
+     * @brief Recalculates the step list for reaching the next waypoint.
+     * @return true if a path was calculated, false if no waypoints remain.
+     * @note Automatically removes reached waypoints from the list.
+     */
     auto recalcStepList() -> bool;
 
 private:
-    std::list<position> positions;
-    Character *_movechar;
-    std::list<direction> steplist;
+    std::list<position> positions; ///< Queue of waypoint positions to visit.
+    Character *_movechar; ///< The character following this waypoint list.
+    std::list<direction> steplist; ///< Calculated step-by-step directions to the next waypoint.
+
+    /**
+     * @brief Checks if the character has reached the current waypoint and removes it if so.
+     * @return true if waypoints remain, false if the list is empty.
+     */
     auto checkPosition() -> bool;
 };
 #endif

--- a/src/World.hpp
+++ b/src/World.hpp
@@ -49,22 +49,32 @@ class NPC;
 class LuaScript;
 
 /**
- * a class for holding gm or player commands
+ * @brief Function signature for GM and player command handlers
+ * 
+ * Command handlers receive the world instance, the player executing the command,
+ * and the command text string. They return true if the command was successfully
+ * executed, false otherwise.
  */
 using CommandType = std::function<bool(World *, Player *, const std::string &)>;
 
 /**
- * a struct for holding Weather informations
+ * @brief Environmental weather conditions for the game world
+ * 
+ * Defines all weather parameters that affect the visual atmosphere of the world.
+ * These values are synchronized to all online players when changed.
+ * 
+ * @see World::setWeather()
+ * @see World::sendWeatherToAllPlayers()
  */
 struct WeatherStruct {
-    char cloud_density = defaultCloudDensity;                   // cloud density in percent
-    char fog_density = defaultFogDensity;                       // fog density in percent
-    char wind_dir = defaultWindDirection;                       // wind direction -100 blowing from east to 100 ???
-    char gust_strength = defaultGustStrength;                   // wind strength in percent
-    char percipitation_strength = defaultPercipitationStrength; // percipitation strength in percent
-    char per_type = defaultPercipitationType;                   // type of percipitation: 0 == rain, 1 == snow
-    char thunderstorm = defaultThunderstormIntensity;           // thunderstorm intensity in percent
-    char temperature = defaultTemperature;                      // current temperature in °C
+    char cloud_density = defaultCloudDensity;                   ///< Cloud density in percent (0-100)
+    char fog_density = defaultFogDensity;                       ///< Fog density in percent (0-100)
+    char wind_dir = defaultWindDirection;                       ///< Wind direction (-100 to 100, -100=from east, 0=north, 100=west)
+    char gust_strength = defaultGustStrength;                   ///< Wind strength in percent (0-100)
+    char percipitation_strength = defaultPercipitationStrength; ///< Precipitation strength in percent (0-100)
+    char per_type = defaultPercipitationType;                   ///< Precipitation type: 0=rain, 1=snow
+    char thunderstorm = defaultThunderstormIntensity;           ///< Thunderstorm intensity in percent (0-100)
+    char temperature = defaultTemperature;                      ///< Current temperature in °C
 
     static constexpr char defaultCloudDensity = 20;
     static constexpr char defaultFogDensity = 0;
@@ -76,17 +86,53 @@ struct WeatherStruct {
     static constexpr char defaultTemperature = 20;
 };
 
+/**
+ * @brief Describes an object or character blocking a field or line of sight
+ * 
+ * Used to identify what is preventing movement or vision at a specific location.
+ * This can be either a character, an item, or nothing at all.
+ */
 struct BlockingObject {
     enum BlockingType { BT_ITEM = 0, BT_CHARACTER = 1, BT_NONE = 2 };
-    BlockingType blockingType = BT_NONE;
-    Character *blockingChar = nullptr;
-    ScriptItem blockingItem;
+    BlockingType blockingType = BT_NONE;   ///< Type of blocking object
+    Character *blockingChar = nullptr;     ///< Pointer to blocking character (if BT_CHARACTER)
+    ScriptItem blockingItem;               ///< Blocking item (if BT_ITEM)
 };
 
 /**
- *this class represents the gameworld
- *this class contains the world of the gameserver
- *here is the main point for monsters, player, maps and npc's
+ * @brief Central singleton managing the game world and all entities within it
+ * 
+ * World is the core manager for the Illarion game server, responsible for:
+ * - Managing all characters (players, monsters, NPCs) and their containers
+ * - Maintaining and updating the world map system
+ * - Processing game loop (turntheworld) with action points
+ * - Handling character movement, item manipulation, and field interactions
+ * - Managing spawn points and monster spawning
+ * - Executing GM and player commands
+ * - Broadcasting messages, weather, and time to clients
+ * - Managing warp fields and teleportation
+ * - Scheduling and executing timed scripts
+ * - Handling combat, line-of-sight, and targeting systems
+ * - Persisting world state to database
+ * 
+ * The World class follows a singleton pattern and must be created via World::create()
+ * before accessing via World::get(). It processes the game in time slices based on
+ * action points (AP), which are distributed to all entities for turn-based mechanics.
+ * 
+ * Implementation is split across multiple files:
+ * - World.cpp: Core loop, initialization, and general functionality
+ * - WorldIMPLCharacterMoves.cpp: Character movement and positioning
+ * - WorldIMPLItemMoves.cpp: Item creation, manipulation, and transfers
+ * - WorldIMPLTools.cpp: Utility functions and field/character lookups
+ * - WorldIMPLTalk.cpp: Message broadcasting and communication
+ * - WorldIMPLAdmin.cpp: GM commands and administrative functions
+ * - WorldIMPLScriptHelp.cpp: Lua script interface implementations
+ * - WorldIMPLPlayer.cpp: Player-specific functionality
+ * 
+ * @note This class is non-copyable and non-movable (singleton pattern)
+ * @see WorldScriptInterface
+ * @see Character
+ * @see map::WorldMap
  */
 class World : public WorldScriptInterface {
 public:
@@ -96,539 +142,1694 @@ public:
     auto operator=(World &&) -> World & = delete;
 
     /////////////////////////
-    NewClientView clientview;
+    NewClientView clientview; ///< View manager for client field-of-view calculations
     /////////////////////////
 
     /**
-     *@todo: change the three vectors @see PLAYERVECTOR, @see MONSTERVECTOR, @see NPCVECTOR so there is only one
-     *HARVECTOR
+     * @brief Container type for all active players
+     * @todo Change the three vectors (PLAYERVECTOR, MONSTERVECTOR, NPCVECTOR) to use a single unified container
      */
     using PLAYERVECTOR = CharacterContainer<Player>;
 
     /**
-     *@todo: change the three vectors @see PLAYERVECTOR, @see MONSTERVECTOR, @see NPCVECTOR so there is only one
-     *HARVECTOR
+     * @brief Container type for all monsters
+     * @todo Change the three vectors (PLAYERVECTOR, MONSTERVECTOR, NPCVECTOR) to use a single unified container
      */
     using MONSTERVECTOR = CharacterContainer<Monster>;
 
     /**
-     *@todo: change the three vectors @see PLAYERVECTOR, @see MONSTERVECTOR, @see NPCVECTOR so there is only one
-     *HARVECTOR
+     * @brief Container type for all NPCs
+     * @todo Change the three vectors (PLAYERVECTOR, MONSTERVECTOR, NPCVECTOR) to use a single unified container
      */
     using NPCVECTOR = CharacterContainer<NPC>;
 
     /**
-     *holds all active player on the world
-     *@todo: change the three vectors @see PLAYERVECTOR, @see MONSTERVECTOR, @see NPCVECTOR so there is only one
-     *HARVECTOR
+     * @brief All currently logged-in players
+     * 
+     * Players are added when they successfully log in and removed when they disconnect
+     * or time out. Access is thread-safe through the CharacterContainer interface.
+     * 
+     * @todo Change the three vectors (PLAYERVECTOR, MONSTERVECTOR, NPCVECTOR) to use a single unified container
      */
     PLAYERVECTOR Players;
 
     /**
-     *sets a new tile on the map
+     * @brief Changes the ground tile at a player's next step position
+     * 
+     * Used for tile drawing/painting by GMs ("turtle" mode). Updates the tile
+     * where the player will move next.
+     * 
+     * @param cp Pointer to the player whose next tile should be changed
+     * @param tilenumber ID of the tile to set
      */
     void setNextTile(Player *cp, unsigned char tilenumber);
 
     /**
-     *holds all monsters on the world
-     *@todo: change the three vectors @see PLAYERVECTOR, @see MONSTERVECTOR, @see NPCVECTOR so there is only one
-     *HARVECTOR
-     **/
+     * @brief All active monsters in the world
+     * 
+     * Monsters are spawned from SpawnPoints and removed when killed. Each monster
+     * maintains a reference to its spawn point for respawn management.
+     * 
+     * @todo Change the three vectors (PLAYERVECTOR, MONSTERVECTOR, NPCVECTOR) to use a single unified container
+     */
     MONSTERVECTOR Monsters;
 
     /**
-     * new Monsters which should be spawned so the server didn't crash on creating monsters from monsters
+     * @brief Queue of monsters waiting to be spawned
+     * 
+     * Monsters scheduled for spawning are placed here and added to the world
+     * in a deferred manner to prevent crashes when monsters create other monsters.
      */
     std::vector<Monster *> newMonsters;
 
     /**
-     *holds all npc's on the world
-     *@todo: change the three vectors @see PLAYERVECTOR, @see MONSTERVECTOR, @see NPCVECTOR so there is only one
-     *HARVECTOR
-     **/
+     * @brief All active NPCs in the world
+     * 
+     * NPCs are loaded from the database at server start and persist until
+     * explicitly deleted or the server shuts down.
+     * 
+     * @todo Change the three vectors (PLAYERVECTOR, MONSTERVECTOR, NPCVECTOR) to use a single unified container
+     */
     NPCVECTOR Npc;
 
     /**
-     *npcs which should be deleted
+     * @brief Character IDs of NPCs pending deletion
+     * 
+     * NPCs marked for deletion are added here and removed in deleteAllLostNPC().
+     * This is a workaround to prevent segfaults when NPCs are sold or removed.
+     * 
+     * @todo Replace with better character lifecycle management using smart pointers and unified container
      */
     std::vector<TYPE_OF_CHARACTER_ID> LostNpcs;
 
     /**
-     * holds the monitoring clients on the World
+     * @brief Manages monitoring/admin client connections
+     * 
+     * Monitoring clients can connect to observe server state and receive diagnostic
+     * messages without being actual players.
      */
     std::unique_ptr<MonitoringClients> monitoringClientList = nullptr;
 
-    std::chrono::steady_clock::time_point startTime;
-    long usedAP{0};
+    std::chrono::steady_clock::time_point startTime; ///< Server start timestamp for uptime calculations
+    long usedAP{0}; ///< Total action points consumed since server start
 
-    int ap{}; /**< actionpoints since the last loop call **/
+    int ap{}; ///< Action points available for current game loop iteration
 
-    ClockBasedScheduler<std::chrono::steady_clock> scheduler;
+    ClockBasedScheduler<std::chrono::steady_clock> scheduler; ///< Manages scheduled script execution
 
-    WeatherStruct weather; /**< a struct to the weather @see WeatherStruct */
+    WeatherStruct weather; ///< Current weather conditions for the world
 
     /**
-     *inline function for setting the current weather and sending the data to all players online
+     * @brief Sets new weather conditions and broadcasts them to all players
+     * 
+     * @param nWeather New weather configuration to apply
+     * @see WeatherStruct
+     * @see sendWeatherToAllPlayers()
      */
     inline void setWeather(WeatherStruct nWeather) {
         weather = nWeather;
         sendWeatherToAllPlayers();
     }
 
-    //! parse GMCommands of the Form !<string1> <string2> and process them
+    /**
+     * @brief Parses and executes GM commands
+     * 
+     * GM commands are prefixed with '!' and provide administrative functions like
+     * teleportation, spawning, reloading, etc. The user must have appropriate
+     * GM rights to execute the command.
+     * 
+     * @param user Player attempting to execute the command
+     * @param text Full command text including the '!' prefix
+     * @return true if a valid command was found and executed, false otherwise
+     * @see parsePlayerCommands()
+     * @see gm_rights
+     */
     auto parseGMCommands(Player *user, const std::string &text) -> bool;
-    //! parse PlayerCommands of the Form !<string1> <string2> and process them
+
+    /**
+     * @brief Parses and executes player commands
+     * 
+     * Player commands are prefixed with '!' and provide utility functions available
+     * to all players, such as language switching or help information.
+     * 
+     * @param player Player executing the command
+     * @param text Full command text including the '!' prefix
+     * @return true if a valid command was found and executed, false otherwise
+     * @see parseGMCommands()
+     */
     auto parsePlayerCommands(Player *player, const std::string &text) -> bool;
 
     /**
-     *the current script which is called
+     * @brief Currently executing Lua script
+     * 
+     * Set during script execution to track context for script callbacks.
+     * nullptr when no script is running.
      */
     LuaScript *currentScript{nullptr};
 
     ~World() override = default;
 
     /**
-     *main loop for the world
+     * @brief Executes one iteration of the main game loop
+     * 
+     * Called repeatedly by the server's main loop to advance game state. Calculates
+     * elapsed time since server start and converts it to action points (AP) based on
+     * MIN_AP_UPDATE constant. Only processes game state if at least 1 AP has accumulated.
+     * 
+     * Each call:
+     * - Calculates elapsed milliseconds and converts to AP
+     * - If AP > 0, calls checkPlayers(), checkMonsters(), and checkNPC() in sequence
+     * - Updates usedAP counter to track total AP consumed
+     * 
+     * The AP system provides a time-sliced, turn-based mechanic where all entities
+     * receive AP proportional to elapsed time, ensuring fair action distribution
+     * regardless of server frame rate.
+     * 
+     * @see checkPlayers()
+     * @see checkMonsters()
+     * @see checkNPC()
      */
     void turntheworld();
 
     /**
-     *checks all player aktions and makes them active
+     * @brief Processes all active players and their pending actions
+     * 
+     * For each online player, this method:
+     * - Checks connection timeout and disconnects idle players
+     * - Distributes action points and fight points
+     * - Processes queued client commands
+     * - Updates fight mode state
+     * - Checks long-term actions and effects
+     * - Periodically saves player data
+     * - Removes disconnected players and notifies visible characters
+     * 
+     * @see Player::workoutCommands()
+     * @see Player::checkFightMode()
      */
     void checkPlayers();
 
+    /**
+     * @brief Invalidates all open dialogs for all players
+     * 
+     * Called when server state changes require closing all dialogs
+     * (e.g., during reload operations).
+     */
     void invalidatePlayerDialogs() const;
 
     /**
-     *checks all actions of the monsters and updates them
+     * @brief Processes all active monsters and their AI behavior
+     * 
+     * For each living monster, this method:
+     * - Checks monstertimer (1-minute interval) and spawns new monsters if enabled
+     * - Consumes 1 AP from the current turn (if ap > 1, decrements ap)
+     * - Distributes action points and fight points to each monster
+     * - Checks and applies long-term effects
+     * - Executes monster AI only if:
+     *   - Monster can act (has sufficient AP)
+     *   - A player is nearby (within MAX_ACT_RANGE) OR monster is on a route
+     * 
+     * Monster AI behavior:
+     * - Target selection using weapon range and visibility
+     * - Calls monster scripts (onAttacked, enemyNear, enemyOnSight)
+     * - Performs attacks if target is in range and monster can fight
+     * - Pathfinding toward last known target position
+     * - Random movement and self-healing when no targets present
+     * - Stays within spawn point range boundaries
+     * 
+     * Dead monsters are collected and removed after iteration completes.
+     * 
+     * @note Monsters are performance-optimized: only monsters near players are processed
+     * @see SpawnPoint
+     * @see Monster
+     * @see isPlayerNearby()
      */
     void checkMonsters();
 
     /**
-     *checks all actions of the NPC's and updates them
+     * @brief Processes all active NPCs and their scripted behavior
+     * 
+     * For each NPC, this method:
+     * - Distributes action points and fight points
+     * - Checks and applies long-term effects
+     * - Executes NPC scripts if a player is nearby
+     * 
+     * @see NPC
+     * @see LuaNPCScript
      */
     void checkNPC();
 
     /**
-     *init method for npc's
-     *loads the npc's from the db and sets them on the map
+     * @brief Loads all NPCs from database and places them in the world
+     * 
+     * Called during server initialization to spawn all persistent NPCs
+     * defined in the database. Each NPC is created with its stored
+     * position, appearance, and associated script.
      */
     void initNPC();
 
     /**
-     *method for creating and starting the scheduler
+     * @brief Initializes and starts the scheduled script system
+     * 
+     * Sets up recurring script execution based on the scheduled scripts
+     * table in the database.
      */
     void initScheduler();
 
     /**
-     * Method for returning the current illarion time
-     *
-     *@param timeType <"year"|"month"|"day"|"hour"|"minute"|"second">
-     *@return a long which is the current illarion time from the type
+     * @brief Gets the current in-game time value
+     * 
+     * Returns various components of the Illarion time system, which has its own
+     * calendar and time progression separate from real-world time.
+     * 
+     * @param timeType One of: "year", "month", "day", "hour", "minute", "second"
+     * @return The requested time component value
+     * @see sendIGTime()
+     * @see sendIGTimeToAllPlayers()
      */
     auto getTime(const std::string &timeType) const -> long override;
 
+    /**
+     * @brief Enables or disables player login
+     * 
+     * When disabled, only GMs with gmr_allowlogin can connect.
+     * Useful for maintenance or testing.
+     * 
+     * @param allow true to allow logins, false to restrict them
+     * @see isLoginAllowed()
+     */
     void allowLogin(bool allow) { _is_login_allowed = allow; }
+
+    /**
+     * @brief Checks if player login is currently allowed
+     * 
+     * @return true if regular players can log in, false if restricted to GMs
+     * @see allowLogin()
+     */
     auto isLoginAllowed() const -> bool { return _is_login_allowed; }
 
+    /**
+     * @brief Enables or disables monster spawning
+     * 
+     * When disabled, spawn points will not create new monsters. Useful
+     * for events or testing scenarios.
+     * 
+     * @param enable true to enable spawning, false to disable
+     * @see isSpawnEnabled()
+     */
     void enableSpawn(bool enable) { _is_spawn_enabled = enable; }
+
+    /**
+     * @brief Checks if monster spawning is currently enabled
+     * 
+     * @return true if monsters can spawn, false otherwise
+     * @see enableSpawn()
+     */
     auto isSpawnEnabled() const -> bool { return _is_spawn_enabled; }
 
+    /**
+     * @brief Creates the singleton World instance
+     * 
+     * Initializes the world with spawn points, GM/player commands, and
+     * monitoring clients. Must be called before World::get().
+     * 
+     * @return Pointer to the created or existing World instance
+     * @see get()
+     */
     static auto create() -> World *;
+
+    /**
+     * @brief Gets the singleton World instance
+     * 
+     * @return Pointer to the World instance
+     * @throws std::runtime_error if World::create() has not been called
+     * @see create()
+     */
     static auto get() -> World *;
 
     /**============ WorldIMPLTools.cpp ==================*/
 
     /**
-     * checks the list of LostNpcs and deletes all the npcs which are in this and the normal npc list
-     * @todo is a bad hack to resolve the problem that segfaults the server on selling cows, should be changed
-     * with a better char handling from the server side (smart pointers, one list for all char types).
+     * @brief Removes all NPCs marked for deletion from the world
+     * 
+     * Processes the LostNpcs list, removing each NPC from its field and
+     * notifying visible players. This is a workaround to prevent segfaults
+     * when NPCs are sold or otherwise removed during gameplay.
+     * 
+     * @todo Replace with better character lifecycle management using smart pointers
+     * @see LostNpcs
      */
     void deleteAllLostNPC();
 
+    /**
+     * @brief Gets the currently executing Lua script
+     * 
+     * @return Pointer to current script, or nullptr if no script is running
+     * @see setCurrentScript()
+     */
     inline auto getCurrentScript() const -> LuaScript * { return currentScript; }
+
+    /**
+     * @brief Sets the currently executing Lua script
+     * 
+     * Used to track script context during execution for error reporting
+     * and script callbacks.
+     * 
+     * @param script Pointer to the script being executed
+     * @see getCurrentScript()
+     */
     inline void setCurrentScript(LuaScript *script) { currentScript = script; }
 
     /**
-     *saves all online players a table in the db
+     * @brief Updates the onlineplayer database table with current players
+     * 
+     * Clears and rebuilds the database table containing all currently
+     * logged-in player IDs. Used for web interfaces and server monitoring.
      */
     void updatePlayerList() const;
 
     /**
-     * finds all warpfields in a given range
-     * can be found in WorldIMPLTools.cpp
-     * @param pos the position from which the warpfields should be found
-     * @param range the roung around pos which should be searched for warpfields
-     * @param call by reference, returns a hashmap with the warpfields which where found
+     * @brief Finds all warp fields within a specified range of a position
+     * 
+     * Searches the map for warp fields (teleportation points) near the given
+     * position, returning their locations.
+     * 
+     * @param pos Center position to search from
+     * @param range Search radius in coordinates
+     * @param warppositions Output vector filled with found warp field positions
+     * @return true if any warp fields were found, false otherwise
      */
     auto findWarpFieldsInRange(const position &pos, Coordinate range, std::vector<position> &warppositions) -> bool;
 
+    /**
+     * @brief Determines all objects blocking line of sight between two positions
+     * 
+     * Uses a line-drawing algorithm to trace from start to end, checking each
+     * field for blocking characters (players) or large items. Returns a list
+     * of all blocking objects encountered along the line.
+     * 
+     * @param startingpos Starting position of the line
+     * @param endingpos Ending position of the line
+     * @return List of BlockingObjects along the line, ordered from start to end
+     * @see BlockingObject
+     */
     auto blockingLineOfSight(const position &startingpos, const position &endingpos) const
             -> std::list<BlockingObject> override;
 
+    /**
+     * @brief Finds all characters in sight within a directional cone
+     * 
+     * Searches for characters in range that are positioned in the specified
+     * facing direction (e.g., all characters north of pos when direction is north).
+     * 
+     * @param pos Origin position
+     * @param range Search radius
+     * @param ret Output vector filled with found characters
+     * @param direction Facing direction to search in
+     * @return true if any characters were found, false otherwise
+     */
     auto findTargetsInSight(const position &pos, Coordinate range, std::vector<Character *> &ret,
                             Character::face_to direction) const -> bool;
+
+    /**
+     * @brief Finds any character standing on the specified field
+     * 
+     * Searches all three character containers (players, monsters, NPCs) for
+     * a character at the given position.
+     * 
+     * @param pos Position to check
+     * @return Pointer to the character found, or nullptr if field is empty
+     * @see findPlayerOnField()
+     */
     auto findCharacterOnField(const position &pos) const -> Character *;
+
+    /**
+     * @brief Finds a player standing on the specified field
+     * 
+     * Only searches the Players container, more efficient than findCharacterOnField
+     * when you know the character type.
+     * 
+     * @param pos Position to check
+     * @return Pointer to the player found, or nullptr if no player present
+     * @see findCharacterOnField()
+     */
     auto findPlayerOnField(const position &pos) const -> Player *;
 
     /**
-     * searches for a special character
-     * can be found in WorldIMPLTools.cpp
-     * looks into all three vectors ( player, monster, npc )  for a character with the given id
-     * @param id the id of the character which should be found
-     * @return a pointer to the character, nullptr if the character wasn't found
-     * @todo has to be changed for only one charactervetor
+     * @brief Searches for a character by their unique ID
+     * 
+     * Searches all three character containers based on ID ranges:
+     * - IDs < MONSTER_BASE: Players
+     * - IDs < NPC_BASE: Monsters (including newMonsters queue)
+     * - IDs >= NPC_BASE: NPCs
+     * 
+     * @param id Character ID to find
+     * @return Pointer to the character, or nullptr if not found
+     * @todo Should be unified when character containers are merged
      */
     virtual auto findCharacter(TYPE_OF_CHARACTER_ID id) -> Character *;
 
     /**
-     *deletes all monsters and npcs from the map and emptys the lists
-     * can be found in WorldIMPLTools.cpp
-     *@see World::Monsters @see World::Npc
+     * @brief Removes all monsters and NPCs from the map and deletes them
+     * 
+     * Clears the Monsters and Npc containers, removing each entity from
+     * its field and freeing memory. Used during server shutdown or reload.
+     * Players are not affected.
+     * 
+     * @see Monsters
+     * @see Npc
      */
     void takeMonsterAndNPCFromMap();
 
     /**
-     * a player attacks
-     * @param cp the player who is attacking
+     * @brief Executes an attack from one character to their current target
+     * 
+     * Resolves a combat action where the character attacks their enemyid target.
+     * Handles attack resolution, death, script callbacks, and target loss notifications.
+     * The character must have an enemy set and the target must be in range.
+     * 
+     * @param cp Attacking character
+     * @return true if attack was executed, false if target not found/out of range
+     * @see Character::attack()
      */
     auto characterAttacks(Character *cp) const -> bool;
 
+    /**
+     * @brief Immediately kills a monster and removes it from the world
+     * 
+     * Removes the monster from its field, notifies visible players, and
+     * deletes the monster object. Does not generate loot or call death scripts.
+     * 
+     * @param id Monster's character ID
+     * @return true if monster was found and killed, false otherwise
+     */
     auto killMonster(TYPE_OF_CHARACTER_ID id) -> bool;
 
+    /**
+     * @brief Gets the field at a specific position (mutable)
+     * 
+     * Delegates directly to the WorldMap's at() method.
+     * 
+     * @param pos Position to retrieve
+     * @return Reference to the field
+     * @throws FieldNotFound if position is not loaded or outside any map boundary
+     */
     auto fieldAt(const position &pos) -> map::Field & override;
+
+    /**
+     * @brief Gets the field at a specific position (const)
+     * 
+     * Delegates directly to the WorldMap's at() method.
+     * 
+     * @param pos Position to retrieve
+     * @return Const reference to the field
+     * @throws FieldNotFound if position is not loaded or outside any map boundary
+     */
     auto fieldAt(const position &pos) const -> const map::Field & override;
+
+    /**
+     * @brief Finds the first non-transparent field at or below a position
+     * 
+     * Iterates downward from the given position for up to RANGEDOWN+1 levels (typically 2),
+     * checking each z-level until a solid (non-transparent) field is found.
+     * 
+     * The position parameter is modified to the z-level where the solid field was found.
+     * This is useful for determining where items/characters actually rest when placed
+     * on transparent tiles like air.
+     * 
+     * @param pos Starting position (modified to the found field's position)
+     * @return Reference to the first non-transparent field
+     * @throws FieldNotFound if all checked levels are transparent or out of range
+     */
     auto fieldAtOrBelow(position &pos) -> map::Field &;
+
+    /**
+     * @brief Finds a walkable field near the specified position
+     * 
+     * Delegates to walkableNear() utility function which searches adjacent fields
+     * for one that is not blocked by terrain, items, or characters.
+     * 
+     * @param pos Target position
+     * @return Reference to a nearby walkable field
+     * @throws FieldNotFound if no walkable field is nearby
+     */
     auto walkableFieldNear(const position &pos) -> map::Field &;
+
+    /**
+     * @brief Marks a field as persistent (should be saved to disk)
+     * 
+     * Persistent fields have their tile and item data saved when the map
+     * is written to disk, preserving player/GM modifications across server restarts.
+     * Delegates to WorldMap::makePersistentAt().
+     * 
+     * @param pos Position to mark as persistent
+     */
     void makePersistentAt(const position &pos) override;
+
+    /**
+     * @brief Removes persistence marking from a field
+     * 
+     * The field will revert to its default state on next server restart,
+     * discarding any runtime modifications. Delegates to WorldMap::removePersistenceAt().
+     * 
+     * @param pos Position to unmark
+     */
     void removePersistenceAt(const position &pos) override;
+
+    /**
+     * @brief Checks if a field is marked as persistent
+     * 
+     * Delegates to WorldMap::isPersistentAt().
+     * 
+     * @param pos Position to check
+     * @return true if field is persistent, false otherwise
+     */
     auto isPersistentAt(const position &pos) const -> bool override;
 
+    /**
+     * @brief Retrieves a specific attribute value for an item type
+     * 
+     * Queries various item data tables (armor, weapon, tiles modificator, common items)
+     * for specific attributes. Used primarily for scripting and item analysis.
+     * 
+     * Supported attributes:
+     * - Armor: "bodyparts", "strokearmor", "thrustarmor", "armormagicdisturbance"
+     * - Weapon: "accuracy", "attack", "defence", "range", "weapontype", "weaponmagicdisturbance"
+     * - Item: "agingspeed", "objectafterrot", "weight"
+     * - Tiles: "modificator"
+     * 
+     * @param s Attribute name to query
+     * @param ItemID Item type ID
+     * @return Attribute value, or 0 if attribute/item not found
+     */
     static auto getItemAttrib(const std::string &s, TYPE_OF_ITEM_ID ItemID) -> int;
 
+    /**
+     * @brief Loads all world maps from disk
+     * 
+     * Attempts to load saved map files. If loading fails, falls back to
+     * importing from the map editor format.
+     * 
+     * @see Save()
+     * @see import()
+     */
     void Load();
+
+    /**
+     * @brief Saves all world maps to disk
+     * 
+     * Persists modified map data to disk files for preservation across
+     * server restarts.
+     * 
+     * @see Load()
+     */
     void Save() const;
+
+    /**
+     * @brief Imports maps from map editor format
+     * 
+     * Forces import of maps from editor files, overwriting any existing
+     * runtime or saved data. Used for deploying new map versions.
+     * 
+     * @see Load()
+     */
     void import();
+
+    /**
+     * @brief Creates a new map area in the world
+     * 
+     * @param name Map identifier/name
+     * @param origin Top-left corner position
+     * @param width Map width in tiles
+     * @param height Map height in tiles
+     * @param tile Default tile ID to fill the map with
+     * @return true if map was created successfully, false otherwise
+     */
     auto createMap(const std::string &name, const position &origin, uint16_t width, uint16_t height, uint16_t tile)
             -> bool {
         return maps.createMap(name, origin, width, height, tile);
     }
 
+    /**
+     * @brief Notifies all visible players that a character was removed
+     * 
+     * Sends character removal messages to all players who can see the
+     * specified position. Used when characters die, disconnect, or teleport.
+     * 
+     * @param id Character ID that was removed
+     * @param pos Position where the character was removed from
+     */
     void sendRemoveCharToVisiblePlayers(TYPE_OF_CHARACTER_ID id, const position &pos) const;
 
+    /**
+     * @brief Notifies all visible players of a character's health change
+     * 
+     * Updates health bars displayed by player clients for visible characters.
+     * 
+     * @param cc Character whose health changed
+     * @param health New health value
+     */
     void sendHealthToAllVisiblePlayers(Character *cc, Attribute::attribute_t health) const;
 
     /**============in WorldIMPLCharacterMoves.cpp==================*/
 
     /**
-     *sends all character to a client which the player sees
-     *
-     *@param cp pointer to the player which should recive the data
-     *@param sendSpin if true the direction of the chars is also sendet
+     * @brief Sends all visible characters to a player's client
+     * 
+     * Used when a player logs in or their view changes significantly.
+     * Populates the player's client with all characters currently visible
+     * within their screen range.
+     * 
+     * @param cp Player who should receive character data
+     * @param sendSpin If true, also sends character facing directions
      */
     void sendAllVisibleCharactersToPlayer(Player *cp, bool sendSpin);
 
     /**
-     *adds a warpfield to a specific groundtile
-     *
-     *changes also the groundtile and adds a item on it
-     *@param where the starting position of the warpfield (from where is the char warped)
-     *@param target the ending position of the warpfield (to where is the char warped)
-     *@param starttilenr the id of the new groundtile which should be set. 0 for no changes
-     *@param startitemnr the id of a new item which should be placed at the start position. 0 for no changes
-     *@return true if the adding of the warpfield was succesfull otherwise false
+     * @brief Creates a one-way warp field with optional tile/item changes
+     * 
+     * Establishes a teleportation point that transports characters from
+     * 'where' to 'target'. Optionally modifies the starting tile and/or
+     * places an item marker at the warp location.
+     * 
+     * @param where Starting position of the warp field
+     * @param target Destination position where characters are teleported
+     * @param starttilenr Tile ID to set at warp location (0 = no change)
+     * @param startitemnr Item ID to place at warp location (0 = no change)
+     * @return true if warp field was successfully created, false otherwise
+     * @see removeWarpField()
      */
     auto addWarpField(const position &where, const position &target, unsigned short int starttilenr,
                       Item::id_type startitemnr) -> bool;
 
     /**
-     *adds a two way warpfield to the map
-     *
-     *changes also the groundtile/item of the startpos and endinpos and adds a way back
-     *
-     *@param where the starting position of the warpfield (from where is the char warped)
-     *@param target the ending position of the warpfield (to where is the char warped)
-     *@param starttilenr the id of the new groundtile at the starting position. 0 for no changes
-     *@param startitemnr the id of a new item which should be added at the starting pos. 0 for no changes
-     *@param targettilenr the id of the new groundtile at the target position. 0 for no changes
-     *@param targetitemnr the id of a new item which should be added at the target pos. 0 for no changes
-     *@return true if the adding of the warpfield was succesfull otherwise false
+     * @brief Creates a bidirectional warp field pair
+     * 
+     * Establishes two linked teleportation points that transport characters
+     * between 'where' and 'target' in both directions. Optionally modifies
+     * tiles and places items at both locations.
+     * 
+     * @param where First warp field position
+     * @param target Second warp field position
+     * @param starttilenr Tile ID at first position (0 = no change)
+     * @param startitemnr Item ID at first position (0 = no change)
+     * @param targettilenr Tile ID at second position (0 = no change)
+     * @param targetitemnr Item ID at second position (0 = no change)
+     * @return true if both warp fields were successfully created, false otherwise
+     * @see addWarpField()
+     * @see removeWarpField()
      */
     auto addWarpField(const position &where, const position &target, unsigned short int starttilenr,
                       Item::id_type startitemnr, unsigned short int targettilenr, Item::id_type targetitemnr) -> bool;
 
     /**
-     *removes a warpfield at a given position
-     *
-     *@param where the position of the warpfield which should be removed
-     *@return true if the removing was succesfull otherwise false
+     * @brief Removes a warp field at the specified position
+     * 
+     * @param pos Position of the warp field to remove
+     * @return true if warp field was found and removed, false otherwise
+     * @see addWarpField()
      */
     auto removeWarpField(const position &pos) -> bool;
 
     /**
-     * looks for the targetposition of a Warpfield
-     *
-     *@param where the starting coordinate of the warpfield
-     *@param target call by reference, returns the target position of the warpfield
-     *@return true if the warpfield was found otherwise false
-     */
-    // bool findWarpFieldTarget( position where, position &target );
-
-    /**
-     *calls a triggerscript if a character is moving to a triggerfield or away from one
-     *
-     *@param cc the character which is moving
-     *@param true if the char is moving to the field, false if he is moving away from the field
+     * @brief Triggers field scripts when a character moves to/from a field
+     * 
+     * Calls Lua trigger scripts associated with the character's current
+     * field position, notifying the script of entrance or exit.
+     * 
+     * @param cc Character that is moving
+     * @param moveto true if moving onto the field, false if moving away
+     * @see checkFieldAfterMove()
      */
     static void triggerFieldMove(Character *cc, bool moveto);
 
     /**
-     * update the character container about the position change
-     *@param cc the character which is moving
-     *@param from the old position
-     *@param to the new position
+     * @brief Updates character container indices after position change
+     * 
+     * Must be called after a character's position is modified to maintain
+     * the spatial indexing used by character containers for efficient lookups.
+     * 
+     * @param cc Character that moved
+     * @param to New position of the character
      */
     void moveTo(Character *cc, const position &to);
 
     /**
-     *moves a player to the direction d
-     *@param cp pointer to the player which should be moved
-     *@param d the direction to he is moving:
-     *
-     *<ul>
-     *<li> 0 - North</li>
-     *<li> 1 - Northwest (not used)</li>
-     *<li> 2 - West </li>
-     *<li> 3 - Southwest (not used) </li>
-     *<li> 4 - South </li>
-     *<li> 5 - Southeast </li>
-     *<li> 6 - East </li>
-     *<li> 7 - Northeast </li>
-     *<li> 8 - up </li>
-     *<li> 9 - down </li>
-     *
-     *@param walkcost call by reference, returns the walking cost of the move
-     *@param active true if the walking should be animated otherwise false
-     *@param pushSelf true if the player was pushing himself otherwise false
-     *@return true if the movement was succesful otherwise false
-     *@todo Player->move was implemented this function can be deleted
-     **/
+     * @brief Moves a player in a specific direction
+     * 
+     * Handles player movement including collision detection, walking cost
+     * calculation, and animation. Updates the player's position and facing
+     * direction if movement is successful.
+     * 
+     * @param cp Player to move
+     * @param d Direction to move (0=North, 2=West, 4=South, 6=East, 8=up, 9=down)
+     * @param walkcost Output parameter receiving the movement cost in tenths of a second
+     * @return true if movement was successful, false if blocked or invalid
+     * @todo Can be deprecated in favor of Player::move()
+     */
     auto pushPlayer(Player *cp, unsigned char d, short int &walkcost) -> bool;
 
+    /**
+     * @brief Triggers field effects after a character moves onto a field
+     * 
+     * Checks for special items and trigger fields at the character's new
+     * position, calling associated Lua scripts. Used for traps, teleporters,
+     * and other field-based mechanics.
+     * 
+     * @param character Character that just moved
+     * @param field Field the character moved onto
+     * @see triggerFieldMove()
+     */
     static void checkFieldAfterMove(Character *character, const map::Field &field);
+
+    /**
+     * @brief Notifies visible players of a character's passive (pushed) movement
+     * 
+     * Used when a character is pushed, knocked back, or otherwise moved
+     * without walking normally.
+     * 
+     * @param ccp Character that was moved passively
+     */
     void sendPassiveMoveToAllVisiblePlayers(Character *ccp) const;
+
+    /**
+     * @brief Notifies visible players of a character's facing direction change
+     * 
+     * @param cc Character that turned/spun
+     */
     void sendSpinToAllVisiblePlayers(Character *cc) const;
+
+    /**
+     * @brief Notifies visible players of a character's movement
+     * 
+     * Sends movement animation commands to all players who can see the
+     * character's position.
+     * 
+     * @param cc Character that moved
+     * @param moveType Type of movement (NORMALMOVE, RUNNING, etc.)
+     * @param duration Movement duration in tenths of a second
+     */
     void sendCharacterMoveToAllVisiblePlayers(Character *cc, unsigned char moveType,
                                               TYPE_OF_WALKINGCOST duration) const;
+
+    /**
+     * @brief Notifies visible characters of a character's movement
+     * 
+     * Similar to sendCharacterMoveToAllVisiblePlayers but only sends to players.
+     * Uses NORMALMOVE type.
+     * 
+     * @param cc Character that moved
+     * @param duration Movement duration in tenths of a second
+     */
     void sendCharacterMoveToAllVisibleChars(Character *cc, TYPE_OF_WALKINGCOST duration) const;
+
+    /**
+     * @brief Notifies visible players of a character's teleportation/warp
+     * 
+     * Handles the network updates when a character instantly moves from one
+     * position to another (not walking). Removes character from old position
+     * and adds at new position for affected players.
+     * 
+     * @param cc Character that warped
+     * @param oldpos Position before teleportation
+     * @param moveType Type of warp movement
+     */
     void sendCharacterWarpToAllVisiblePlayers(Character *cc, const position &oldpos, unsigned char moveType) const;
+
+    /**
+     * @brief Template helper for sending character data to a player
+     * 
+     * @tparam T Character type (Player, Monster, or NPC)
+     * @param vec Vector of characters to send
+     * @param cp Player who should receive the data
+     * @param sendSpin If true, also send facing directions
+     */
     template <class T> void sendCharsInVector(const std::vector<T *> &vec, Player *cp, bool sendSpin);
 
+    /**
+     * @brief Sends item information when a player looks at a map item
+     * 
+     * Generates and sends detailed item information including name, description,
+     * and custom script data when a player examines an item on the ground.
+     * 
+     * @param player Player performing the look action
+     * @param pos Position of the item on the map
+     * @param stackPos Index of the item in the field's item stack
+     */
     void lookAtMapItem(Player *player, const position &pos, uint8_t stackPos);
 
 private:
+    /**
+     * @brief Sends tile information when a player looks at a map tile
+     * 
+     * @param cp Player performing the look action
+     * @param tile Tile ID being examined
+     * @param pos Position of the tile
+     */
     static void lookAtTile(Player *cp, unsigned short int tile, const position &pos);
 
 public:
-    //! sendet an den Spieler den Namen des Item an einer Position im showcase
-    // \param cp der Spieler der benachrichtigt werden soll
-    // \param showcase der showcase in dem das Item liegt
-    // \param position die Position des Item im showcase
+    /**
+     * @brief Sends item information when a player looks at a showcase item
+     * 
+     * Showcases are opened containers displayed to the player. This sends
+     * detailed information about an item in an open showcase.
+     * 
+     * @param cp Player performing the look action
+     * @param showcase Showcase ID (which open container)
+     * @param position Item position within the showcase
+     */
     void lookAtShowcaseItem(Player *cp, uint8_t showcase, unsigned char position);
 
-    //! sendet an den Spieler den Namen des Item an einer Position im Inventory
-    // \param cp der Spieler der benachrichtigt werden soll
-    // \param position die Position des Item im Inventory
+    /**
+     * @brief Sends item information when a player looks at an inventory item
+     * 
+     * Sends detailed information about an item in the player's belt or body slots.
+     * 
+     * @param cp Player performing the look action
+     * @param position Inventory slot being examined
+     */
     void lookAtInventoryItem(Player *cp, unsigned char position);
 
+    /**
+     * @brief Plays a sound effect for all players within range
+     * 
+     * @param pos Origin position of the sound
+     * @param radius Hearing radius in coordinates
+     * @param sound Sound effect ID to play
+     */
     void makeSoundForAllPlayersInRange(const position &pos, int radius, unsigned short int sound) const;
+
+    /**
+     * @brief Shows a graphical effect for all players within range
+     * 
+     * @param pos Origin position of the effect
+     * @param radius Visibility radius in coordinates
+     * @param gfx Graphics effect ID to display
+     */
     void makeGFXForAllPlayersInRange(const position &pos, int radius, unsigned short int gfx) const;
 
-    //! send a message to all chars near pos
-    //! \param message what the char says
-    //! \param tt did he shout/talk/whisper?
-    //! \param the talking char
+    /**
+     * @brief Broadcasts a message to all characters within speech range
+     * 
+     * Sends a single-language message to all characters (players, monsters, NPCs)
+     * within range based on talk type. Range depends on whisper/say/yell.
+     * 
+     * @param message Message text to send
+     * @param tt Talk type (whisper, say, or yell)
+     * @param cc Speaking character
+     * @see sendMessageToAllCharsInRange(const std::string&, const std::string&, Character::talk_type, Character*)
+     */
     void sendMessageToAllCharsInRange(const std::string &message, Character::talk_type tt, Character *cc) const;
+
+    /**
+     * @brief Broadcasts a bilingual message to all characters within speech range
+     * 
+     * Sends German and English versions of a message to all characters within
+     * range. Players receive the appropriate language based on their client settings.
+     * 
+     * @param german German version of the message
+     * @param english English version of the message
+     * @param tt Talk type (whisper, say, or yell)
+     * @param cc Speaking character
+     */
     void sendMessageToAllCharsInRange(const std::string &german, const std::string &english, Character::talk_type tt,
                                       Character *cc) const;
 
     /**
-     *Sends a message in a specific language to all chars in range with this language
-     *@param message what the chars says
-     *@param tt shout/talk/whisper
-     *@param lang the language to which players the message is send
-     *@param cc the talking char
-     *@todo remove deprecated function
+     * @brief Sends a language-specific message to characters with that language skill
+     * 
+     * Only characters who understand the specified language will receive the message.
+     * Messages are prefixed with language indicator (e.g., "[hum]" for human language).
+     * 
+     * @param message Message text
+     * @param tt Talk type (whisper, say, or yell)
+     * @param lang Language ID (see Language enum)
+     * @param cc Speaking character
+     * @todo This function is deprecated in favor of client-side language handling
      */
     void sendLanguageMessageToAllCharsInRange(const std::string &message, Character::talk_type tt, Language lang,
                                               Character *cc) const;
 
+    /**
+     * @brief Sends a message to all online players
+     * 
+     * Broadcasts a single-language message to every logged-in player regardless
+     * of position. Used for server announcements.
+     * 
+     * @param message Message to broadcast
+     * @see broadcast()
+     */
     void sendMessageToAllPlayers(const std::string &message) const;
+
+    /**
+     * @brief Broadcasts a bilingual message to all online players
+     * 
+     * Sends German and English versions to all players, with each player
+     * receiving their appropriate language version.
+     * 
+     * @param german German version of the message
+     * @param english English version of the message
+     */
     void broadcast(const std::string &german, const std::string &english) const override;
 
+    /**
+     * @brief Sends a message to all GMs with gmr_getgmcalls permission
+     * 
+     * Used for GM notifications, help requests, and administrative alerts.
+     * 
+     * @param message Message to send to GMs
+     * @see gm_rights
+     */
     void sendMessageToAdmin(const std::string &message) const;
 
+    /**
+     * @brief Converts a language ID to its skill name
+     * 
+     * @param languageId Language ID constant (languageHuman, languageDwarf, etc.)
+     * @return Skill name string (e.g., "human language", "dwarf language")
+     * @see languagePrefix()
+     */
     static auto languageNumberToSkillName(int languageId) -> std::string;
+
+    /**
+     * @brief Gets the chat prefix for a language
+     * 
+     * Returns the bracketed prefix shown in chat for language-specific messages.
+     * 
+     * @param languageId Language ID constant
+     * @return Prefix string (e.g., "[hum] ", "[dwa] ", or "" for common)
+     * @see languageNumberToSkillName()
+     */
     static auto languagePrefix(int languageId) -> std::string;
 
+    /**
+     * @brief Calculates the hearing range for a talk type
+     * 
+     * @param tt Talk type (whisper, say, or yell)
+     * @return Range structure with radius and zRadius values
+     */
     static auto getTalkRange(Character::talk_type tt) -> Range;
 
+    /**
+     * @brief Triggers player introduction to nearby characters
+     * 
+     * Called when a player speaks, allowing nearby players to learn their name
+     * through the introduction system.
+     * 
+     * @param cp Player who is introducing themselves
+     * @see forceIntroducePlayer()
+     * @see ForceIntroduce()
+     */
     void introduceMyself(Player *cp) const;
+
+    /**
+     * @brief Forces one player to learn another player's name
+     * 
+     * Used by GMs to grant knowledge of a player's identity without
+     * normal introduction process.
+     * 
+     * @param cp Player to introduce
+     * @param admin GM forcing the introduction
+     * @see ForceIntroduce()
+     */
     static void forceIntroducePlayer(Player *cp, Player *admin);
+
+    /**
+     * @brief Forces a player to learn character names from text
+     * 
+     * Parses a string of character names and adds them to the player's
+     * known characters list.
+     * 
+     * @param player Player who will learn the names
+     * @param text Space-separated list of character names
+     * @see ForceIntroduceAll()
+     */
     void ForceIntroduce(Player *player, const std::string &text) const;
+
+    /**
+     * @brief Forces a player to know all online character names
+     * 
+     * Grants knowledge of every currently logged-in player's name.
+     * GM command utility.
+     * 
+     * @param player Player who will learn all names
+     * @see ForceIntroduce()
+     */
     void ForceIntroduceAll(Player *player) const;
 
+    /**
+     * @brief Sends current weather data to a specific player
+     * 
+     * @param cp Player to receive weather update
+     * @see sendWeatherToAllPlayers()
+     * @see setWeather()
+     */
     void sendWeather(Player *cp) const;
+
+    /**
+     * @brief Broadcasts current weather to all online players
+     * 
+     * @see sendWeather()
+     * @see setWeather()
+     */
     void sendWeatherToAllPlayers();
 
+    /**
+     * @brief Broadcasts current in-game time to all online players
+     * 
+     * @see sendIGTime()
+     * @see getTime()
+     */
     void sendIGTimeToAllPlayers();
+
+    /**
+     * @brief Sends current in-game time to a specific player
+     * 
+     * @param cp Player to receive time update
+     * @see sendIGTimeToAllPlayers()
+     * @see getTime()
+     */
     void sendIGTime(Player *cp) const;
 
     ////////// in WorldIMPLAdmin.cpp /////////////
 
-    // Sendet eine Message an alle Spieler
-    // param cp: der Spieler der die Message sendet
-    // param message: die nachricht die geschickt wird
+    /**
+     * @brief Broadcasts a message from a GM to all players
+     * 
+     * Sends a message from the specified GM to every online player.
+     * Message appears as a say command in the game world.
+     * 
+     * @param cp GM sending the broadcast
+     * @param message Message text to broadcast
+     */
     void broadcast_command(Player *cp, const std::string &message) const;
 
-    // Kickt alle Spieler aus dem Spiel
-    // param cp: der Spieler welche alle Spieler kickt
+    /**
+     * @brief Kicks all non-GM players from the server
+     * 
+     * Forces disconnection of all regular players while leaving GMs online.
+     * Used for emergency maintenance or server updates.
+     * 
+     * @param cp GM executing the command
+     */
     void kickall_command(Player *cp);
 
-    // Kickt einen einzelnen Spieler aus dem Spiel
-    // param cp: der Spieler welcher jemanden kickt
-    // param player: der Spieler welcher gekickt wird
+    /**
+     * @brief Kicks a specific player from the server
+     * 
+     * Forces disconnection of the named player.
+     * 
+     * @param cp GM executing the kick
+     * @param player Name of the player to kick
+     */
     void kickplayer_command(Player *cp, const std::string &player) const;
 
-    // Zeigt dem Spieler nutzerdaten (IP's) an
+    /**
+     * @brief Displays IP addresses of all online players to a GM
+     * 
+     * Shows connection information for all logged-in players.
+     * Used for identifying multi-accounts or connection issues.
+     * 
+     * @param cp GM requesting the information
+     */
     static void showIPS_Command(Player *cp);
 
     /**
-     *creates an item in the inventory of the gm
+     * @brief Creates an item in the GM's inventory
+     * 
+     * Generates a new item with the specified ID and adds it to the GM's
+     * inventory for testing or events.
+     * 
+     * @param cp GM creating the item
+     * @param itemid Item ID to create (as string)
      */
     static void create_command(Player *cp, const std::string &itemid);
 
+    /**
+     * @brief Spawns a monster near the GM
+     * 
+     * Creates a monster of the specified type at a position near the GM.
+     * Used for testing or live events.
+     * 
+     * @param cp GM spawning the monster
+     * @param monsterId Monster type ID (as string)
+     */
     void spawn_command(Player *cp, const std::string &monsterId);
 
     /**
-     * activates a specific logfile
+     * @brief Activates a specific logging facility
+     * 
+     * Enables detailed logging for a particular subsystem (e.g., "World", "Script").
+     * Used for debugging specific server components.
+     * 
+     * @param cp GM enabling the log
+     * @param log Name of the logging facility to activate
+     * @see logoff_command()
      */
     void logon_command(Player *cp, const std::string &log);
 
     /**
-     * deactivates a specific logfile
+     * @brief Deactivates a specific logging facility
+     * 
+     * Disables detailed logging for a particular subsystem.
+     * 
+     * @param cp GM disabling the log
+     * @param log Name of the logging facility to deactivate
+     * @see logon_command()
      */
     void logoff_command(Player *cp, const std::string &log);
 
-    //! teleportiert einen Player zu einem anderen
-    // \param cp der zu teleportierende Player
-    // \param ts der Name des Ziel - Player
+    /**
+     * @brief Teleports a GM to another player's location
+     * 
+     * Instantly moves the GM to the position of the named player.
+     * Also known as "jump to" or "goto" command.
+     * 
+     * @param player GM to teleport
+     * @param target Name of the target player
+     * @see jumpto_command()
+     */
     void teleportPlayerToOther(Player *player, const std::string &target) const;
 
-    //! toetet alles auf der Karte befindlichen Monster
+    /**
+     * @brief Kills all monsters on the map
+     * 
+     * Removes every monster from the world instantly. Used for clearing
+     * spawns during events or after testing.
+     * 
+     * @param cp GM executing the command
+     */
     void kill_command(Player *cp) const;
 
-    //! resambles the former #r command, reloads all tables, definitions and scripts
-    // \param cp is the GM performing this full reload
+    /**
+     * @brief Performs a full reload of tables, definitions, and scripts
+     * 
+     * Reloads all game data from the database and filesystem without
+     * restarting the server. Equivalent to the former #r command.
+     * This includes:
+     * - Item, monster, NPC tables
+     * - All Lua scripts
+     * - Spawn points
+     * - Quests and skills
+     * 
+     * @param cp GM initiating the reload
+     * @see reload_defs()
+     */
     void reload_command(Player *cp);
 
-    //! substitutes #j <name>, jump to a player of a given name
-    // \param cp is the jumping GM
-    // \param ts name of the player to jump to
+    /**
+     * @brief Teleports a GM to a player's location
+     * 
+     * Alias for teleportPlayerToOther(). Substitutes the #j command.
+     * 
+     * @param cp GM jumping to another player
+     * @param player Name of the target player
+     * @see teleportPlayerToOther()
+     */
     void jumpto_command(Player *cp, const std::string &player) const;
 
-    //! resambles the former #mapsave command, saves the map
-    // \param cp the corresponding GM with correct rights who initiates this mapsave
+    /**
+     * @brief Saves all world maps to disk
+     * 
+     * Forces immediate persistence of map data. Equivalent to #mapsave.
+     * 
+     * @param cp GM requesting the save
+     * @see Save()
+     */
     void save_command(Player *cp);
 
-    //! Macht spieler cp unsichtbar
+    /**
+     * @brief Makes a player invisible to others
+     * 
+     * Sets invisibility flag, hiding the GM from other players' views.
+     * The GM can still see and interact with the world normally.
+     * 
+     * @param cp GM to make invisible
+     * @see makeVisible()
+     */
     void makeInvisible(Player *cp) const;
 
+    /**
+     * @brief Speaks a message as another player
+     * 
+     * Allows a GM to send a message that appears to come from another
+     * player. Used for roleplaying events or testing.
+     * 
+     * @param player GM using the command
+     * @param text Format: "player_name message text"
+     */
     void talkto_command(Player *player, const std::string &text) const;
 
-    //! Macht spieler cp sichtbar
+    /**
+     * @brief Makes an invisible player visible again
+     * 
+     * Removes invisibility flag, making the GM visible to other players.
+     * 
+     * @param cp GM to make visible
+     * @see makeInvisible()
+     */
     void makeVisible(Player *cp) const;
 
-    //! wirft alle Player aus dem Spiel
+    /**
+     * @brief Forces logout of all players
+     * 
+     * Disconnects every player from the server, including GMs.
+     * Used for emergency shutdowns.
+     */
     void forceLogoutOfAllPlayers();
 
-    //! wirft einen aktiven Player aus dem Spiel
-    // \param name der Spieler der herausgeworfen werden soll
-    // \return true falls der Player gefunden wurde, false sonst
+    /**
+     * @brief Forces logout of a specific player
+     * 
+     * Disconnects the named player from the server.
+     * 
+     * @param name Player name to log out
+     * @return true if player was found and logged out, false otherwise
+     */
     auto forceLogoutOfPlayer(const std::string &name) const -> bool;
 
-    //! sendet einem Admin die Daten aller aktiven Player
-    // \param admin der Admin an den die Daten gesandt werden sollen
+    /**
+     * @brief Sends detailed information about all online players to a GM
+     * 
+     * Displays comprehensive player data including position, stats, and
+     * connection information.
+     * 
+     * @param admin GM requesting the information
+     */
     static void sendAdminAllPlayerData(Player *admin);
 
-    // ! Server side implemented !warp_to x y z
+    /**
+     * @brief Warps a GM to specific coordinates
+     * 
+     * Server-side implementation of !warp_to x y z command. Teleports
+     * the GM to the specified position.
+     * 
+     * @param player GM to warp
+     * @param text Coordinates in format "x y z"
+     */
     static void warpto_command(Player *player, const std::string &text);
 
-    // ! Server side implemented !summon Player
+    /**
+     * @brief Summons a player to the GM's location
+     * 
+     * Teleports the named player to the GM's current position.
+     * Server-side implementation of !summon command.
+     * 
+     * @param player GM doing the summoning
+     * @param text Name of player to summon
+     */
     void summon_command(Player *player, const std::string &text) const;
 
-    // ! relaods only the definition from the db no Monsterspawns and no NPC's are loaded.
+    /**
+     * @brief Reloads only game data definitions without scripts
+     * 
+     * Reloads database tables (items, monsters, etc.) but does not
+     * reload Lua scripts, NPCs, or spawn points. Faster than full reload.
+     * 
+     * @param cp GM requesting the reload
+     * @return true if reload was successful, false otherwise
+     * @see reload_command()
+     */
     auto reload_defs(Player *cp) const -> bool;
 
-    // ! adds Warpfields to map from textfile
+    /**
+     * @brief Imports warp fields from a text file
+     * 
+     * Reads warp field definitions from a file and adds them to the map.
+     * Used for bulk teleporter setup.
+     * 
+     * @param cp GM importing the warp fields
+     * @param filename Path to the warp field definition file
+     * @return true if import was successful, false otherwise
+     */
     auto importWarpFields(Player *cp, const std::string &filename) -> bool;
 
-    // ! Deletes a Warpfield
+    /**
+     * @brief Removes a warp field at specified coordinates
+     * 
+     * Deletes a teleporter from the map.
+     * 
+     * @param cp GM removing the warp field
+     * @param text Coordinates in format "x y z"
+     * @see addWarpField()
+     */
     void removeTeleporter(Player *cp, const std::string &text);
 
-    // ! Shows a list of Warpfields
+    /**
+     * @brief Shows all warp fields within a radius
+     * 
+     * Displays information about nearby warp fields to the GM.
+     * 
+     * @param cp GM requesting the list
+     * @param text Radius to search (as string)
+     * @see findWarpFieldsInRange()
+     */
     void showWarpFieldsInRange(Player *cp, const std::string &text);
     //////////////////////////////////////////////////////////////////
 
     //////////// in WorldIMPLItemMoves.cpp ////////////////
 
+    /**
+     * @brief Global temporary item for atomic item transfer operations
+     * 
+     * Used as a temporary holding location during item moves. All item manipulation
+     * functions use this global to transfer items between locations (map, inventory,
+     * showcases). This avoids complex parameter passing but requires careful sequencing
+     * of take/put operations.
+     * 
+     * @warning Not thread-safe - assumes single-threaded game loop execution
+     */
     Item g_item;
+    
+    /**
+     * @brief Global temporary container for atomic container transfer operations
+     * 
+     * Used when moving containers between locations. Works in conjunction with g_item
+     * to handle container transfers with their contents intact.
+     * 
+     * @warning Not thread-safe - assumes single-threaded game loop execution
+     */
     Container *g_cont{};
 
+    /**
+     * @brief Removes an item from the map and places it in g_item
+     * 
+     * @param cc Character taking the item
+     * @param itemPosition Map position of the item
+     * @return true if item was successfully taken, false otherwise
+     */
     auto takeItemFromMap(Character *cc, const position &itemPosition) -> bool;
+
+    /**
+     * @brief Places g_item onto the map if the field is not blocked
+     * 
+     * @param cc Character placing the item
+     * @param itemPosition Target map position
+     * @return true if item was successfully placed, false if blocked
+     */
     auto putItemOnMap(Character *cc, const position &itemPosition) -> bool;
+
+    /**
+     * @brief Places g_item onto the map regardless of blocking
+     * 
+     * @param cc Character placing the item
+     * @param itemPosition Target map position
+     * @return true if item was successfully placed
+     */
     auto putItemAlwaysOnMap(Character *cc, const position &itemPosition) -> bool;
+
+    /**
+     * @brief Takes an item from character inventory and places it in g_item
+     * 
+     * @param cc Character whose inventory to take from
+     * @param pos Inventory slot position
+     * @param count Number of items to take
+     * @return true if item was successfully taken, false otherwise
+     */
     auto takeItemFromInvPos(Character *cc, unsigned char pos, Item::number_type count) -> bool;
+
+    /**
+     * @brief Places g_item into character inventory at specified slot
+     * 
+     * Atomic operation that attempts to place g_item from the global temporary into
+     * a character's inventory. Handles:
+     * - Backpack placement (only containers, sets backPackContents)
+     * - Body slot placement with equipment rules (armor body parts, two-handed weapons)
+     * - Two-handed weapons block opposite hand slot with BLOCKEDITEM
+     * - Stackable items merge with existing stacks if same type and data
+     * - Updates character appearance to all visible players on success
+     * - Clears g_item and g_cont on successful placement
+     * 
+     * @param cc Character whose inventory receives the item
+     * @param pos Target inventory slot (0-17, or BACKPACK)
+     * @return true if item was successfully placed, false if blocked or incompatible
+     * @see takeItemFromInvPos()
+     */
     auto putItemOnInvPos(Character *cc, unsigned char pos) -> bool;
+
+    /**
+     * @brief Takes an item from player inventory and places it in g_item
+     * 
+     * Player-specific version with additional checks.
+     * 
+     * @param cc Player whose inventory to take from
+     * @param pos Inventory slot position
+     * @param count Number of items to take
+     * @return true if item was successfully taken, false otherwise
+     */
     auto takeItemFromInvPos(Player *cc, unsigned char pos, Item::number_type count) -> bool;
+
+    /**
+     * @brief Places g_item into player inventory
+     * 
+     * Player-specific version with additional checks and notifications.
+     * 
+     * @param cc Player whose inventory to place into
+     * @param pos Target inventory slot
+     * @return true if item was successfully placed, false otherwise
+     */
     auto putItemOnInvPos(Player *cc, unsigned char pos) -> bool;
 
+    /**
+     * @brief Closes showcases for other players viewing a container
+     * 
+     * When a container is moved, this closes it for all other players
+     * who had it open to prevent desyncs.
+     * 
+     * @param target Player moving the container
+     * @param moved Container being moved
+     */
     void closeShowcaseForOthers(Player *target, Container *moved) const;
+
+    /**
+     * @brief Closes showcase if container is moved out of range
+     * 
+     * @param moved Container that was moved
+     * @param showcasePosition Position where container was located
+     */
     void closeShowcaseIfNotInRange(Container *moved, const position &showcasePosition) const;
 
+    /**
+     * @brief Takes an item from an open showcase and places it in g_item
+     * 
+     * @param cc Player taking from showcase
+     * @param showcase Showcase ID
+     * @param pos Item position in showcase
+     * @param count Number of items to take
+     * @return true if item was successfully taken, false otherwise
+     */
     auto takeItemFromShowcase(Player *cc, uint8_t showcase, unsigned char pos, Item::number_type count) -> bool;
+
+    /**
+     * @brief Places g_item into an open showcase
+     * 
+     * @param cc Player placing into showcase
+     * @param showcase Showcase ID
+     * @param pos Target slot in showcase
+     * @return true if item was successfully placed, false otherwise
+     */
     auto putItemInShowcase(Player *cc, uint8_t showcase, TYPE_OF_CONTAINERSLOTS pos) -> bool;
+
+    /**
+     * @brief Checks and triggers field scripts after item manipulation
+     * 
+     * @param field Field to check
+     * @param itemPosition Position of the field
+     */
     void checkField(const map::Field &field, const position &itemPosition) const;
 
+    /**
+     * @brief Moves an item from one map position to another
+     * 
+     * @param cp Player performing the move
+     * @param oldPosition Source position
+     * @param newPosition Destination position
+     * @param count Number of items to move
+     * @return true if move was successful, false otherwise
+     */
     auto moveItemFromMapToMap(Player *cp, const position &oldPosition, const position &newPosition,
                               Item::number_type count) -> bool;
+
+    /**
+     * @brief Moves an item from map into an open showcase
+     * 
+     * @param cp Player performing the move
+     * @param sourcePosition Map position of item
+     * @param showcase Showcase ID
+     * @param showcaseSlot Target slot in showcase
+     * @param count Number of items to move
+     */
     void moveItemFromMapIntoShowcase(Player *cp, const position &sourcePosition, uint8_t showcase,
                                      unsigned char showcaseSlot, Item::number_type count);
+
+    /**
+     * @brief Moves an item from map into player inventory
+     * 
+     * @param cp Player performing the move
+     * @param sourcePosition Map position of item
+     * @param inventorySlot Target inventory slot
+     * @param count Number of items to move
+     */
     void moveItemFromMapToPlayer(Player *cp, const position &sourcePosition, unsigned char inventorySlot,
                                  Item::number_type count);
+
+    /**
+     * @brief Moves an item from one showcase to another
+     * 
+     * @param cp Player performing the move
+     * @param source Source showcase ID
+     * @param pos Source slot position
+     * @param dest Destination showcase ID
+     * @param pos2 Destination slot position
+     * @param count Number of items to move
+     */
     void moveItemBetweenShowcases(Player *cp, uint8_t source, unsigned char pos, uint8_t dest, unsigned char pos2,
                                   Item::number_type count);
+
+    /**
+     * @brief Drops an item from showcase onto the map
+     * 
+     * @param cp Player performing the drop
+     * @param showcase Showcase ID
+     * @param pos Item slot in showcase
+     * @param newPosition Target map position
+     * @param count Number of items to drop
+     */
     void dropItemFromShowcaseOnMap(Player *cp, uint8_t showcase, unsigned char pos, const position &newPosition,
                                    Item::number_type count);
+
+    /**
+     * @brief Moves an item from showcase to player inventory
+     * 
+     * @param cp Player performing the move
+     * @param showcase Showcase ID
+     * @param pos Item slot in showcase
+     * @param cpos Target inventory slot
+     * @param count Number of items to move
+     */
     void moveItemFromShowcaseToPlayer(Player *cp, uint8_t showcase, unsigned char pos, unsigned char cpos,
                                       Item::number_type count);
+
+    /**
+     * @brief Moves an item between inventory slots
+     * 
+     * @param cp Player performing the move
+     * @param opos Old inventory position
+     * @param npos New inventory position
+     * @param count Number of items to move
+     */
     void moveItemBetweenBodyParts(Player *cp, unsigned char opos, unsigned char npos, Item::number_type count);
+
+    /**
+     * @brief Drops an item from player inventory onto the map
+     * 
+     * @param cp Player dropping the item
+     * @param cpos Inventory slot position
+     * @param newPosition Target map position
+     * @param count Number of items to drop
+     */
     void dropItemFromPlayerOnMap(Player *cp, unsigned char cpos, const position &newPosition, Item::number_type count);
+
+    /**
+     * @brief Moves an item from player inventory into a showcase
+     * 
+     * @param cp Player performing the move
+     * @param cpos Inventory slot position
+     * @param showcase Showcase ID
+     * @param pos Target slot in showcase
+     * @param count Number of items to move
+     */
     void moveItemFromPlayerIntoShowcase(Player *cp, unsigned char cpos, uint8_t showcase, unsigned char pos,
                                         Item::number_type count);
+
+    /**
+     * @brief Picks up an item from the map into player inventory
+     * 
+     * Automatically finds an appropriate inventory slot for the item.
+     * 
+     * @param cp Player picking up the item
+     * @param itemPosition Map position of item
+     * @return true if item was picked up, false otherwise
+     */
     auto pickUpItemFromMap(Player *cp, const position &itemPosition) -> bool;
+
+    /**
+     * @brief Picks up all items at player's position
+     * 
+     * Attempts to pick up every item on the field the player is standing on.
+     * 
+     * @param cp Player picking up items
+     */
     void pickUpAllItemsFromMap(Player *cp);
 
+    /**
+     * @brief Notifies visible characters that an item was removed from map
+     * 
+     * @param itemPosition Position where item was removed
+     */
     void sendRemoveItemFromMapToAllVisibleCharacters(const position &itemPosition) const;
+
+    /**
+     * @brief Notifies visible characters that an item was placed on map
+     * 
+     * @param itemPosition Position where item was placed
+     * @param it Item that was placed
+     */
     void sendPutItemOnMapToAllVisibleCharacters(const position &itemPosition, const Item &it) const;
+
+    /**
+     * @brief Notifies visible characters that an item on map changed
+     * 
+     * @param id Item ID that changed
+     * @param itemPosition Position of the item
+     * @param it New item state
+     */
     void sendSwapItemOnMapToAllVisibleCharacter(TYPE_OF_ITEM_ID id, const position &itemPosition, const Item &it) const;
+
+    /**
+     * @brief Notifies players viewing a container that a slot changed
+     * 
+     * Version for when a container was moved.
+     * 
+     * @param cc Container that changed
+     * @param slot Slot that changed
+     * @param moved Container that was in the slot (if any)
+     */
     void sendContainerSlotChange(Container *cc, TYPE_OF_CONTAINERSLOTS slot, Container *moved) const;
+
+    /**
+     * @brief Notifies players viewing a container that a slot changed
+     * 
+     * @param cc Container that changed
+     * @param slot Slot that changed
+     */
     void sendContainerSlotChange(Container *cc, TYPE_OF_CONTAINERSLOTS slot) const;
 
     //////////////////////////////////////In WorldIMPLScriptHelp.cpp//////////////////////////////////////////
 
+    /**
+     * @brief Deletes a dynamic NPC from the world
+     * 
+     * Removes an NPC that was created at runtime (not from database).
+     * 
+     * @param npcid NPC character ID to delete
+     * @return true if NPC was found and deleted, false otherwise
+     */
     auto deleteNPC(unsigned int npcid) -> bool override;
 
+    /**
+     * @brief Creates a dynamic NPC at runtime
+     * 
+     * Spawns a new NPC with the specified properties and script.
+     * The NPC is not persisted to the database.
+     * 
+     * @param name NPC name
+     * @param type Race type ID
+     * @param pos Position to spawn at
+     * @param sex NPC gender
+     * @param scriptname Lua script file to attach
+     * @return true if NPC was created successfully, false otherwise
+     */
     auto createDynamicNPC(const std::string &name, TYPE_OF_RACE_ID type, const position &pos, Character::sex_type sex,
                           const std::string &scriptname) -> bool override;
 
@@ -646,7 +1847,18 @@ public:
     auto getItemStats(const ScriptItem &item) const -> ItemStruct override;
     auto getItemStatsFromId(TYPE_OF_ITEM_ID id) const -> ItemStruct override;
     void changeQuality(ScriptItem item, int amount) override;
+
+    /**
+     * @brief Notifies scripts that a player is looking at an item
+     * 
+     * Allows item scripts to provide custom descriptions and information.
+     * 
+     * @param user Player looking at the item
+     * @param item Item being examined
+     * @param lookAt Structure to fill with description data
+     */
     virtual void itemInform(Character *user, const ScriptItem &item, const ItemLookAt &lookAt);
+
     auto getItemName(TYPE_OF_ITEM_ID itemid, uint8_t language) const -> std::string override;
     auto changeItem(ScriptItem item) -> bool override;
 
@@ -671,12 +1883,17 @@ public:
 
     void changeTile(short int tileid, const position &pos) override;
 
-    //! Sicherer CreateArea command, prft erst ab ob er eine vorhandene Map berschreibt.
-    //\tileid: standard Tile
-    //\pos: begin der neuen Karte
-    //\height: Hoehe der neuen Karte
-    //\width: breite der neuen Karte
-    //\return true wenn das einfgen klappte, ansonsten false wenns zu berlagerungen kommt.
+    /**
+     * @brief Creates a new map area without overwriting existing maps
+     * 
+     * Safe version that checks for overlaps before creating.
+     * 
+     * @param tile Default tile ID
+     * @param origin Top-left corner position
+     * @param height Map height
+     * @param width Map width
+     * @return true if area was created, false if it would overlap
+     */
     auto createSavedArea(uint16_t tile, const position &origin, uint16_t height, uint16_t width) -> bool override;
 
     auto getArmorStruct(TYPE_OF_ITEM_ID id, ArmorStruct &ret) -> bool override;
@@ -685,120 +1902,282 @@ public:
     auto getMonsterAttack(TYPE_OF_RACE_ID id, AttackBoni &ret) -> bool override;
 
     /**
-     *sends a Message to All Monitoring Clients
-     *@param msg the message string which should be sended
-     *@param id the id of the msg ( 1 are message which displayed in a window 0 basic message)
+     * @brief Sends a message to all monitoring clients
+     * 
+     * Monitoring clients are external tools that observe server state.
+     * 
+     * @param msg Message to send
+     * @param id Message type ID (0=basic, 1=popup window)
      */
     void sendMonitoringMessage(const std::string &msg, unsigned char id = 0) const override;
 
     /**
-     * bans a player for the bantime
-     * @param cp pointer to the player which should been banned
-     * @param bantime in seconds
-     * @gmid the id of the gm which has banned the player
+     * @brief Bans a player for a specified duration
+     * 
+     * @param cp Player to ban
+     * @param bantime Duration in seconds
+     * @param gmid GM ID who issued the ban
      */
     void ban(Player *cp, int bantime, TYPE_OF_CHARACTER_ID gmid) const;
 
+    /**
+     * @brief Sets login permissions for the server
+     * 
+     * @param player GM setting the login state
+     * @param text "on" to enable logins, "off" to disable
+     */
     void set_login(Player *player, const std::string &text);
 
 protected:
-    World(); // used for testcases
-    static World *_self;
+    World(); ///< Protected constructor for testing
+
+    static World *_self; ///< Singleton instance pointer
 
 private:
+    /**
+     * @brief Logs when a required field is not found
+     * 
+     * @param function Function name where the error occurred
+     * @param field Position that was not found
+     */
     static void logMissingField(const std::string &function, const position &field);
 
-    bool _is_login_allowed = true;
-    bool _is_spawn_enabled = true;
+    bool _is_login_allowed = true; ///< Whether regular players can log in
+    bool _is_spawn_enabled = true; ///< Whether monsters should spawn
 
     /**
-     * the constructor of World, private because of singleton pattern
-     *
-     *@param dir the main directory of the server
-     *@param time_t the starting time of the server
+     * @brief Private constructor for World singleton
+     * 
+     * Initializes the world state:
+     * - Sets lastTurnIGDay to current in-game day
+     * - Records startTime for AP calculations
+     * - Constructs scriptDir path from config datadir + SCRIPTSDIR
+     * 
+     * Called only by create(). The public World(const std::string&) constructor
+     * exists but is never used in practice.
+     * 
+     * @see create()
      */
     explicit World(const std::string &dir);
 
-    //! IG day of last turntheworld
-    int lastTurnIGDay;
+    int lastTurnIGDay; ///< In-game day of last turntheworld() call (used to detect day changes for aging)
 
-    Timer monstertimer{std::chrono::minutes(1)};
+    Timer monstertimer{std::chrono::minutes(1)}; ///< 1-minute interval timer for spawn point processing
 
+    /**
+     * @brief Ages all map items by one tick
+     */
     void ageMaps();
+
+    /**
+     * @brief Ages all items in character inventories
+     */
     void ageInventory() const;
 
-    std::string scriptDir;
+    std::string scriptDir; ///< Directory containing Lua scripts
 
-    // spawnplaces...
-    std::list<SpawnPoint> SpawnList;
+    std::list<SpawnPoint> SpawnList; ///< All monster spawn points
 
-    // initmethod for spawn places...
+    /**
+     * @brief Loads spawn points from database
+     * 
+     * @return true if loading was successful, false otherwise
+     */
     auto initRespawns() -> bool;
 
     using CommandMap = std::map<std::string, CommandType>;
-    CommandMap GMCommands;
-    CommandMap PlayerCommands;
+    CommandMap GMCommands;     ///< Map of GM command names to handlers
+    CommandMap PlayerCommands; ///< Map of player command names to handlers
 
-    // Send player information to GMs
+    /**
+     * @brief Shows information about a specific player to a GM
+     * 
+     * @param cp GM requesting information
+     * @param tplayer Name of player to query
+     */
     void who_command(Player *cp, const std::string &tplayer) const;
 
-    // Change tile in front of admin
+    /**
+     * @brief Changes the tile in front of a GM
+     * 
+     * @param cp GM changing the tile
+     * @param tile Tile ID to set
+     */
     void tile_command(Player *cp, const std::string &tile);
 
-    // Turtle tile commands
+    /**
+     * @brief Enables turtle tile painting mode
+     * 
+     * @param cp GM enabling turtle mode
+     * @param tile Tile ID to paint with
+     */
     static void turtleon_command(Player *cp, const std::string &tile);
+
+    /**
+     * @brief Disables turtle tile painting mode
+     * 
+     * @param cp GM disabling turtle mode
+     */
     static void turtleoff_command(Player *cp);
 
-    // Clipping on/off command
+    /**
+     * @brief Enables clipping (walking through walls)
+     * 
+     * @param cp GM enabling clipping
+     */
     static void clippingon_command(Player *cp);
+
+    /**
+     * @brief Disables clipping
+     * 
+     * @param cp GM disabling clipping
+     */
     static void clippingoff_command(Player *cp);
 
-    // Describe to admin tile in front of them
+    /**
+     * @brief Describes the tile and items in front of a GM
+     * 
+     * @param cp GM requesting information
+     */
     void what_command(Player *cp);
 
-    // Save all online players
+    /**
+     * @brief Saves all online players to database
+     * 
+     * @param cp GM requesting the save
+     */
     void playersave_command(Player *cp) const;
 
-    // Create telport warp on current tile to x, y, z
+    /**
+     * @brief Creates a warp field on current tile
+     * 
+     * @param cp GM creating the warp
+     * @param text Target coordinates "x y z"
+     */
     void teleport_command(Player *cp, const std::string &text);
 
-    // Give help for GM commands
+    /**
+     * @brief Displays available GM commands
+     * 
+     * @param cp GM requesting help
+     */
     static void gmhelp_command(Player *cp);
 
-    // Sendet eine Nachricht an alle GM's
+    /**
+     * @brief Sends a GM help request ticket
+     * 
+     * @param player Player requesting GM help
+     * @param ticket Help request message
+     * @return true if ticket was submitted successfully
+     */
     auto gmpage_command(Player *player, const std::string &ticket) const -> bool;
 
 public:
+    /**
+     * @brief Processes ban command with parameters
+     * 
+     * @param cp GM issuing the ban
+     * @param text Ban parameters (player name, duration, reason)
+     */
     void ban_command(Player *cp, const std::string &text) const;
+
+    /**
+     * @brief Logs a GM help ticket to database
+     * 
+     * @param player Player submitting ticket
+     * @param ticket Ticket message
+     * @param automatic Whether ticket was auto-generated
+     */
     void logGMTicket(Player *player, const std::string &ticket, bool automatic) const;
+
+    /**
+     * @brief Processes immediate player commands from queue
+     * 
+     * Handles commands that must be executed immediately outside
+     * the normal game loop timing.
+     */
     void checkPlayerImmediateCommands();
+
+    /**
+     * @brief Adds a player to the immediate command queue
+     * 
+     * @param player Player with urgent commands to process
+     */
     void addPlayerImmediateActionQueue(Player *player);
 
 private:
-    map::WorldMap maps;
+    map::WorldMap maps; ///< World map management system
 
+    /**
+     * @brief Gets all characters within radius (players, monsters, NPCs)
+     * 
+     * @param pos Center position
+     * @param radius Search radius
+     * @return Vector of all characters in range
+     */
     auto getTargetsInRange(const position &pos, int radius) const -> std::vector<Character *>;
 
+    /**
+     * @brief Activates a language for the player
+     * 
+     * @param cp Player changing language
+     * @param language Language name
+     * @return true if language was activated successfully
+     */
     static auto active_language_command(Player *cp, const std::string &language) -> bool;
 
-    // register any GM commands here...
+    /**
+     * @brief Registers all GM commands with their handlers
+     */
     void InitGMCommands();
-    // register any Player commands here...
+
+    /**
+     * @brief Registers all player commands with their handlers
+     */
     void InitPlayerCommands();
+
+    /**
+     * @brief Executes a user command if it exists
+     * 
+     * @param user User executing the command
+     * @param input Full command string
+     * @param commands Command map to search (GM or player)
+     * @return true if command was found and executed
+     */
     auto executeUserCommand(Player *user, const std::string &input, const CommandMap &commands) -> bool;
 
-    // export maps to mapdir/export
+    /**
+     * @brief Exports all maps to mapdir/export
+     * 
+     * @param cp GM requesting export
+     * @return true if export was successful
+     */
     auto exportMaps(Player *cp) const -> bool;
 
+    /**
+     * @brief Skips comment lines in an input stream
+     * 
+     * @param inputStream Stream to process
+     */
     void ignoreComments(std::ifstream &inputStream);
 
-    //! reload all tables
+    /**
+     * @brief Reloads all game data tables from database
+     * 
+     * @param cp GM requesting reload
+     * @return true if reload was successful
+     */
     auto reload_tables(Player *cp) -> bool;
 
+    /**
+     * @brief Displays server version information
+     * 
+     * @param player Player requesting version info
+     */
     static void version_command(Player *player);
 
-    std::mutex immediatePlayerCommandsMutex;
-    std::queue<Player *> immediatePlayerCommands;
+    std::mutex immediatePlayerCommandsMutex;            ///< Mutex for immediate command queue
+    std::queue<Player *> immediatePlayerCommands;       ///< Queue of players with immediate commands
 };
 
 #endif

--- a/src/WorldScriptInterface.hpp
+++ b/src/WorldScriptInterface.hpp
@@ -36,6 +36,14 @@ class NPC;
 class Player;
 struct WeaponStruct;
 
+/**
+ * @brief Abstract interface for Lua scripts to interact with the game world.
+ * 
+ * Provides script-callable methods for character manipulation, item operations,
+ * map queries, and data table lookups without exposing full World implementation.
+ * 
+ * @see World
+ */
 class WorldScriptInterface {
 public:
     WorldScriptInterface() = default;

--- a/src/character_ptr.hpp
+++ b/src/character_ptr.hpp
@@ -25,24 +25,76 @@
 
 class Character;
 
+/**
+ * @brief A smart pointer for Character objects that stores character IDs instead of raw pointers.
+ *
+ * This class provides a safe way to reference characters by storing their ID and looking them up
+ * through the World when accessed. This prevents dangling pointers when characters are removed
+ * from the game world. The pointer automatically becomes invalid if the character no longer exists.
+ */
 class character_ptr {
-    TYPE_OF_CHARACTER_ID id{0};
+    TYPE_OF_CHARACTER_ID id{0}; ///< The ID of the referenced character, or 0 if null.
 
 public:
+    /**
+     * @brief Default constructor creating a null character pointer.
+     */
     character_ptr() = default;
+
+    /**
+     * @brief Constructs a character pointer from a Character raw pointer.
+     * @param p The Character pointer to wrap, or nullptr.
+     */
     explicit character_ptr(Character *p);
 
+    /**
+     * @brief Gets the Character pointer, throwing if invalid.
+     * @return A pointer to the Character.
+     * @throws std::logic_error if the character no longer exists.
+     */
     [[nodiscard]] auto get() const -> Character *;
+
+    /**
+     * @brief Implicit conversion to Character pointer.
+     * @return A pointer to the Character.
+     * @throws std::logic_error if the character no longer exists.
+     */
     operator Character *() const;
+
+    /**
+     * @brief Arrow operator for accessing Character members.
+     * @return A pointer to the Character.
+     * @throws std::logic_error if the character no longer exists.
+     */
     auto operator->() const -> Character *;
+
+    /**
+     * @brief Checks if the character pointer is valid (character still exists).
+     * @return true if the character exists, false otherwise.
+     */
     operator bool() const;
 
 private:
+    /**
+     * @brief Looks up the Character pointer from the stored ID.
+     * @return A pointer to the Character, or nullptr if not found.
+     */
     [[nodiscard]] auto getPointerFromId() const -> Character *;
 };
 
+/**
+ * @brief Helper function to get the raw pointer from a character_ptr.
+ * @param p The character_ptr to extract from.
+ * @return A pointer to the Character.
+ * @throws std::logic_error if the character no longer exists.
+ */
 auto get_pointer(character_ptr const &p) -> Character *;
 
+/**
+ * @brief Checks if a character_ptr points to a valid character.
+ * @param p The character_ptr to check.
+ * @return true if the character exists, false otherwise.
+ */
 auto isValid(character_ptr const &p) -> bool;
 
 #endif

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -16,6 +16,22 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with illarionserver.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * @file constants.hpp
+ * @brief Global game constants and configuration values.
+ *
+ * Defines fundamental game parameters including:
+ * - Character attribute limits (HP, mana, food, stats)
+ * - Map and visibility ranges
+ * - Equipment slot indices and body part flags
+ * - Character ID ranges for monsters, NPCs, and dynamic NPCs
+ * - Tile and field flags for pathfinding and special effects
+ * - Network protocol constants
+ * - Disconnect reason codes
+ * - Language identifiers
+ * - Time conversion factors for in-game calendar
+ */
+
 #ifndef CONSTANTS_HPP
 #define CONSTANTS_HPP
 
@@ -27,49 +43,49 @@
 #include <string>
 
 #ifdef SYSLOG
-constexpr bool useSysLog = true;
+constexpr bool useSysLog = true; ///< Use system logging if compiled with -DSYSLOG
 #else
-constexpr bool useSysLog = false;
+constexpr bool useSysLog = false; ///< Use file-based logging
 #endif
 
-constexpr auto illarionBirthTime = 950742000; // 17.2.2000 (UTC+1)
-constexpr auto illarionTimeFactor = 3;
+constexpr auto illarionBirthTime = 950742000; ///< Unix timestamp of Illarion epoch (Feb 17, 2000, UTC+1)
+constexpr auto illarionTimeFactor = 3; ///< In-game time passes 3x faster than real time
 
-constexpr auto maxDataKeyLength = 255;
-constexpr auto maxDataValueLength = 255;
+constexpr auto maxDataKeyLength = 255; ///< Maximum length for item data map keys
+constexpr auto maxDataValueLength = 255; ///< Maximum length for item data map values
 
-constexpr uint32_t DYNNPC_BASE = 0xFF800000;
-constexpr uint32_t NPC_BASE = 0xFF000000;
-constexpr uint32_t MONSTER_BASE = 0xFE000000;
+constexpr uint32_t DYNNPC_BASE = 0xFF800000; ///< Base ID for dynamically created NPCs
+constexpr uint32_t NPC_BASE = 0xFF000000; ///< Base ID for static NPCs
+constexpr uint32_t MONSTER_BASE = 0xFE000000; ///< Base ID for monsters
 static_assert(MONSTER_BASE < NPC_BASE);
 static_assert(NPC_BASE < DYNNPC_BASE);
 
-constexpr auto MONSTERVIEWRANGE = 11;
-constexpr auto MAX_SCREEN_RANGE = 30;
-constexpr auto MAX_ACT_RANGE = 60;
+constexpr auto MONSTERVIEWRANGE = 11; ///< Tiles a monster can see in any direction
+constexpr auto MAX_SCREEN_RANGE = 30; ///< Maximum client screen range
+constexpr auto MAX_ACT_RANGE = 60; ///< Maximum range for actions/interactions
 
-constexpr auto MAXPOISONVALUE = 400;
-constexpr auto MAXMANA = 10000;
-constexpr auto MAXHPS = 10000;
-constexpr auto MAXFOOD = 60000;
-constexpr auto MAXATTRIB = 255;
-constexpr auto MAXWEIGHT = 30000;
+constexpr auto MAXPOISONVALUE = 400; ///< Maximum poison intensity value
+constexpr auto MAXMANA = 10000; ///< Maximum mana points
+constexpr auto MAXHPS = 10000; ///< Maximum hit points
+constexpr auto MAXFOOD = 60000; ///< Maximum food/satiation value
+constexpr auto MAXATTRIB = 255; ///< Maximum value for any character attribute
+constexpr auto MAXWEIGHT = 30000; ///< Maximum carry weight in mass units
 
-constexpr auto WAITINGVALIDATION = 1;
-constexpr auto BANNED = 30;
-constexpr auto BANNEDFORTIME = 31;
+constexpr auto WAITINGVALIDATION = 1; ///< Account status: awaiting email validation
+constexpr auto BANNED = 30; ///< Account status: permanently banned
+constexpr auto BANNEDFORTIME = 31; ///< Account status: temporarily banned
 
-constexpr std::array<int, 2> DEPOTITEMS = {321, 4817};
-constexpr auto DEPOTSIZE = 100;
-constexpr auto BLOCKEDITEM = 228;
+constexpr std::array<int, 2> DEPOTITEMS = {321, 4817}; ///< Item IDs that function as depot chests
+constexpr auto DEPOTSIZE = 100; ///< Maximum items per depot
+constexpr auto BLOCKEDITEM = 228; ///< Item ID used to block map tiles
 
-constexpr auto FLAG_WARPFIELD = 1;
-constexpr auto FLAG_SPECIALITEM = 2;
-constexpr auto FLAG_BLOCKPATH = 4;
-constexpr auto FLAG_MAKEPASSABLE = 8;
-constexpr auto FLAG_MONSTERONFIELD = 16;
-constexpr auto FLAG_NPCONFIELD = 32;
-constexpr auto FLAG_PLAYERONFIELD = 64;
+constexpr auto FLAG_WARPFIELD = 1; ///< Tile flag: triggers teleportation
+constexpr auto FLAG_SPECIALITEM = 2; ///< Item/tile flag: has special scripted behavior
+constexpr auto FLAG_BLOCKPATH = 4; ///< Tile/item flag: blocks character movement
+constexpr auto FLAG_MAKEPASSABLE = 8; ///< Item flag: allows movement through blocking tiles
+constexpr auto FLAG_MONSTERONFIELD = 16; ///< Field flag: monster occupies this tile
+constexpr auto FLAG_NPCONFIELD = 32; ///< Field flag: NPC occupies this tile
+constexpr auto FLAG_PLAYERONFIELD = 64; ///< Field flag: player occupies this tile
 
 // Verwendung siehe Tabelle:
 // WERT|      tiles        |   tilesmoditems   |       flags        |
@@ -92,150 +108,150 @@ constexpr auto FLAG_PLAYERONFIELD = 64;
 // ----+-------------------+-------------------+--------------------+
 
 //! das Verzeichnis der Karte, relativ zum DEFAULTMUDDIR
-const std::string MAPDIR("map/");
+const std::string MAPDIR("map/"); ///< Map files directory path relative to server root
 
 //! das Verzeichnis der Skripte, relativ zum DEFAULTMUDDIR
-const std::string SCRIPTSDIR("scripts/");
+const std::string SCRIPTSDIR("scripts/"); ///< Lua scripts directory path relative to server root
 
 //! Anzahl der maximal sichtbaren Ebenen nach Oben
-constexpr Coordinate RANGEUP = 2;
+constexpr Coordinate RANGEUP = 2; ///< Number of Z-levels visible above player
 
 //! Anzahl der maximal sichtbaren Ebenen nach Unten
-constexpr Coordinate RANGEDOWN = 2;
+constexpr Coordinate RANGEDOWN = 2; ///< Number of Z-levels visible below player
 
 //! Anzahl der Felder zwischen zwei Ebenen
-constexpr Coordinate LEVELDISTANCE = 3;
+constexpr Coordinate LEVELDISTANCE = 3; ///< Vertical tile distance between Z-levels
 
 //! Typ der maximalen Anzahl von Item in einem Container
-using MAXCOUNTTYPE = unsigned char;
+using MAXCOUNTTYPE = unsigned char; ///< Type for item count in containers (max 255)
 
 //! Die maximale Anzahl von Item auf einem Feld
-constexpr auto MAXITEMS = 250; // max 255 da oft als BYTE verwendet
+constexpr auto MAXITEMS = 250; ///< Maximum items on a single map tile (limited by byte representation)
 
 //! die maximale Anzahl von Item am Grtel
-constexpr auto MAX_BELT_SLOTS = 6;
+constexpr auto MAX_BELT_SLOTS = 6; ///< Number of quick-access belt slots
 
 //! Die maximale Anzahl von Item direkt am K�per
-constexpr auto MAX_BODY_ITEMS = 12;
+constexpr auto MAX_BODY_ITEMS = 12; ///< Number of equipment slots on character body
 
-constexpr auto BACKPACK = 0;
-constexpr auto HEAD = 1;
-constexpr auto NECK = 2;
-constexpr auto BREAST = 3;
-constexpr auto HANDS = 4;
-constexpr auto LEFT_TOOL = 5;
-constexpr auto RIGHT_TOOL = 6;
-constexpr auto FINGER_LEFT_HAND = 7;
-constexpr auto FINGER_RIGHT_HAND = 8;
-constexpr auto LEGS = 9;
-constexpr auto FEET = 10;
-constexpr auto COAT = 11;
-constexpr auto LAST_WEARABLE = 11;
-constexpr auto BELT1 = 12;
-constexpr auto BELT2 = 13;
-constexpr auto BELT3 = 14;
-constexpr auto BELT4 = 15;
-constexpr auto BELT5 = 16;
-constexpr auto BELT6 = 17;
+constexpr auto BACKPACK = 0; ///< Equipment slot: backpack/bag
+constexpr auto HEAD = 1; ///< Equipment slot: head (helmet)
+constexpr auto NECK = 2; ///< Equipment slot: neck (amulet)
+constexpr auto BREAST = 3; ///< Equipment slot: chest (armor)
+constexpr auto HANDS = 4; ///< Equipment slot: hands (gloves)
+constexpr auto LEFT_TOOL = 5; ///< Equipment slot: left hand tool/weapon
+constexpr auto RIGHT_TOOL = 6; ///< Equipment slot: right hand tool/weapon
+constexpr auto FINGER_LEFT_HAND = 7; ///< Equipment slot: left ring finger
+constexpr auto FINGER_RIGHT_HAND = 8; ///< Equipment slot: right ring finger
+constexpr auto LEGS = 9; ///< Equipment slot: legs (pants/leggings)
+constexpr auto FEET = 10; ///< Equipment slot: feet (boots)
+constexpr auto COAT = 11; ///< Equipment slot: coat/cloak
+constexpr auto LAST_WEARABLE = 11; ///< Index of last wearable equipment slot
+constexpr auto BELT1 = 12; ///< Belt slot 1
+constexpr auto BELT2 = 13; ///< Belt slot 2
+constexpr auto BELT3 = 14; ///< Belt slot 3
+constexpr auto BELT4 = 15; ///< Belt slot 4
+constexpr auto BELT5 = 16; ///< Belt slot 5
+constexpr auto BELT6 = 17; ///< Belt slot 6
 
-constexpr uint8_t FLAG_HEAD = 0b0000'0001;
-constexpr uint8_t FLAG_NECK = 0b0000'0010;
-constexpr uint8_t FLAG_BREAST = 0b0000'0100;
-constexpr uint8_t FLAG_HANDS = 0b0000'1000;
-constexpr uint8_t FLAG_COAT = 0b0001'0000;
-constexpr uint8_t FLAG_FINGER = 0b0010'0000;
-constexpr uint8_t FLAG_LEGS = 0b0100'0000;
-constexpr uint8_t FLAG_FEET = 0b1000'0000;
-constexpr uint8_t FLAG_ALL_SLOTS = 0b1111'1111;
+constexpr uint8_t FLAG_HEAD = 0b0000'0001; ///< Body part flag: head slot
+constexpr uint8_t FLAG_NECK = 0b0000'0010; ///< Body part flag: neck slot
+constexpr uint8_t FLAG_BREAST = 0b0000'0100; ///< Body part flag: chest slot
+constexpr uint8_t FLAG_HANDS = 0b0000'1000; ///< Body part flag: hands slot
+constexpr uint8_t FLAG_COAT = 0b0001'0000; ///< Body part flag: coat slot
+constexpr uint8_t FLAG_FINGER = 0b0010'0000; ///< Body part flag: finger slots
+constexpr uint8_t FLAG_LEGS = 0b0100'0000; ///< Body part flag: legs slot
+constexpr uint8_t FLAG_FEET = 0b1000'0000; ///< Body part flag: feet slot
+constexpr uint8_t FLAG_ALL_SLOTS = 0b1111'1111; ///< Body part flag: all equipment slots
 
-constexpr auto MAXSHOWCASES = 100;
-constexpr auto MAX_DEPOT_SHOWCASE = 9;
+constexpr auto MAXSHOWCASES = 100; ///< Maximum number of open containers per player
+constexpr auto MAX_DEPOT_SHOWCASE = 9; ///< Maximum depot containers that can be open simultaneously
 
 //! Code fr "kein Feld"
-constexpr auto NOFIELD = 0xFFFF;
+constexpr auto NOFIELD = 0xFFFF; ///< Invalid/no field marker value
 
 //-------------- Client to Server ---------------------
 
 //! folgender Wert ist relative x und y Koordinaten eines Items/Bodenplatte/Charakters
-constexpr auto UID_KOORD = 0x01;
+constexpr auto UID_KOORD = 0x01; ///< Network protocol: item reference by map coordinates
 
 //! folgender Wert ist Showcasenummer+showcaseposition
-constexpr auto UID_SHOWC = 0x02;
+constexpr auto UID_SHOWC = 0x02; ///< Network protocol: item reference by container ID and position
 
 //! folgender Wert ist Inventory Position
-constexpr auto UID_INV = 0x03;
+constexpr auto UID_INV = 0x03; ///< Network protocol: item reference by inventory slot
 
 //! Eine Person wird benutzt
-constexpr auto UID_PERSON = 0x05;
+constexpr auto UID_PERSON = 0x05; ///< Network protocol: character interaction
 
-constexpr auto UID_MAGICWAND = 0x06;
+constexpr auto UID_MAGICWAND = 0x06; ///< Network protocol: magic wand usage
 
 //-------------- Server to Client ---------------------
 
-constexpr auto STILLMOVING = 0x09;
-constexpr auto NOMOVE = 0x0A;
-constexpr auto NORMALMOVE = 0x0B;
-constexpr auto PUSH = 0x0C;
-constexpr auto RUNNING = 0x0D;
+constexpr auto STILLMOVING = 0x09; ///< Movement type: character still in motion
+constexpr auto NOMOVE = 0x0A; ///< Movement type: no movement occurred
+constexpr auto NORMALMOVE = 0x0B; ///< Movement type: standard walking
+constexpr auto PUSH = 0x0C; ///< Movement type: pushed by another character
+constexpr auto RUNNING = 0x0D; ///< Movement type: running
 
 //! Grund fr Verbindungsabbruch: Client logt aus
-constexpr auto NORMALLOGOUT = 0x00;
+constexpr auto NORMALLOGOUT = 0x00; ///< Disconnect reason: normal logout
 
 //! Grund fr Verbindungsabbruch: zu alter Client
-constexpr auto OLDCLIENT = 0x01;
+constexpr auto OLDCLIENT = 0x01; ///< Disconnect reason: client version too old
 
 //! Grund fr Verbindungsabbruch: Spieler ist schon online
-constexpr auto DOUBLEPLAYER = 0x02;
+constexpr auto DOUBLEPLAYER = 0x02; ///< Disconnect reason: character already logged in
 
 //! Grund fr Verbindungsabbruch: Falsches Pa�ort
-constexpr auto WRONGPWD = 0x03;
+constexpr auto WRONGPWD = 0x03; ///< Disconnect reason: incorrect password
 
 //! Grund fr Verbindungsabbruch: Servershutdown
-constexpr auto SERVERSHUTDOWN = 0x04;
+constexpr auto SERVERSHUTDOWN = 0x04; ///< Disconnect reason: server shutting down
 
 //! Grund fr Verbindungsabbruch: durch Gamemaster entfernt
-constexpr auto BYGAMEMASTER = 0x05;
+constexpr auto BYGAMEMASTER = 0x05; ///< Disconnect reason: kicked by GM
 
 //! Grund fr Verbindungsabbruch: zum Erstellen eines neuen Player
-constexpr auto FORCREATE = 0x06;
+constexpr auto FORCREATE = 0x06; ///< Disconnect reason: redirect to character creation
 
 //! Grund fr Verbindungsabbruch: kein Platz fr den Player
-constexpr auto NOPLACE = 0x07;
+constexpr auto NOPLACE = 0x07; ///< Disconnect reason: no spawn position available
 
 //! Grund fr Verbindungsabbruch: angegebener Spieler nicht gefunden
-constexpr auto NOCHARACTERFOUND = 0x08;
+constexpr auto NOCHARACTERFOUND = 0x08; ///< Disconnect reason: character not found in database
 
 //! Grund fr Verbindungsabbruch: Spieler wurde erstellt
-constexpr auto PLAYERCREATED = 0x09; // string name
+constexpr auto PLAYERCREATED = 0x09; ///< Disconnect reason: character successfully created
 
 //! Grund fr Verbindungsabbruch: UNSTABLECONNECTION
-constexpr auto UNSTABLECONNECTION = 0x0A; // string name
+constexpr auto UNSTABLECONNECTION = 0x0A; ///< Disconnect reason: connection quality issues
 
 //! Reason for Connection shutdown: player has no account
-constexpr auto NOACCOUNT = 0x0B;
+constexpr auto NOACCOUNT = 0x0B; ///< Disconnect reason: account does not exist
 
 //! Grund fr Verbindungsabbruch: no skill package chosen
-constexpr auto NOSKILLS = 0x0C;
+constexpr auto NOSKILLS = 0x0C; ///< Disconnect reason: no skill package selected during creation
 
 //! Grund fuer Verbindungsabbruch: Spielerdaten korrupt
-constexpr auto CORRUPTDATA = 0x0D;
+constexpr auto CORRUPTDATA = 0x0D; ///< Disconnect reason: corrupted character data
 
-constexpr auto dbStatusNoSkills = 7;
+constexpr auto dbStatusNoSkills = 7; ///< Database status code: character has no skills assigned
 
-constexpr auto languageCommon = 0;
-constexpr auto languageHuman = 1;
-constexpr auto languageDwarf = 2;
-constexpr auto languageElf = 3;
-constexpr auto languageLizard = 4;
-constexpr auto languageOrc = 5;
-constexpr auto languageHalfling = 6;
-constexpr auto languageFairy = 7;
-constexpr auto languageGnome = 8;
-constexpr auto languageGoblin = 9;
-constexpr auto languageAncient = 10;
+constexpr auto languageCommon = 0; ///< Language ID: common tongue (understood by all)
+constexpr auto languageHuman = 1; ///< Language ID: human language
+constexpr auto languageDwarf = 2; ///< Language ID: dwarven language
+constexpr auto languageElf = 3; ///< Language ID: elven language
+constexpr auto languageLizard = 4; ///< Language ID: lizardman language
+constexpr auto languageOrc = 5; ///< Language ID: orcish language
+constexpr auto languageHalfling = 6; ///< Language ID: halfling language
+constexpr auto languageFairy = 7; ///< Language ID: fairy language
+constexpr auto languageGnome = 8; ///< Language ID: gnomish language
+constexpr auto languageGoblin = 9; ///< Language ID: goblin language
+constexpr auto languageAncient = 10; ///< Language ID: ancient/magical language
 
-constexpr auto maximumMajorSkill = 100;
-constexpr auto maximumMinorSkill = 10000;
+constexpr auto maximumMajorSkill = 100; ///< Maximum skill level for major skills
+constexpr auto maximumMinorSkill = 10000; ///< Maximum skill value for minor skills
 
-constexpr auto BBIWIClientVersion = 200;
+constexpr auto BBIWIClientVersion = 200; ///< Required BBIWI (admin client) protocol version
 #endif

--- a/src/data/ArmorObjectTable.hpp
+++ b/src/data/ArmorObjectTable.hpp
@@ -25,11 +25,48 @@
 #include "data/StructTable.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for armor/protective equipment properties
+ *
+ * Loads armor data from the database "armor" table, providing access to
+ * defensive properties for items that function as armor:
+ * - Body parts covered (head, torso, arms, legs, etc.)
+ * - Damage type resistances (puncture, stroke, thrust)
+ * - Magic disturbance penalty
+ * - Damage absorption and stiffness (movement penalty)
+ * - Armor type classification
+ *
+ * Armor properties are looked up by item ID, allowing items to provide
+ * protection when they have an entry in this table.
+ *
+ * Database table: armor
+ */
 class ArmorObjectTable : public StructTable<TYPE_OF_ITEM_ID, ArmorStruct> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "armor"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the armor table
+     * @return Vector containing armor table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract item ID from database row
+     * @param row Database result row
+     * @return Item ID from arm_itemid column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_ITEM_ID override;
+
+    /**
+     * @brief Parse database row into ArmorStruct
+     * @param row Database result row
+     * @return Populated ArmorStruct with armor properties
+     */
     auto assignTable(const Database::ResultTuple &row) -> ArmorStruct override;
 };
 

--- a/src/data/ContainerObjectTable.hpp
+++ b/src/data/ContainerObjectTable.hpp
@@ -24,11 +24,46 @@
 #include "data/StructTable.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for container storage capacity
+ *
+ * Loads container data from the database "container" table, mapping item IDs
+ * to their container slot capacity. Items with entries in this table can hold
+ * other items, with the number of slots determining how many items can be stored.
+ *
+ * This is a simple table that only stores the slot count - no complex data
+ * structure is needed, hence the direct use of TYPE_OF_CONTAINERSLOTS as the
+ * stored value type.
+ *
+ * Database table: container
+ * Columns: con_itemid (item ID), con_slots (number of storage slots)
+ */
 class ContainerObjectTable : public StructTable<TYPE_OF_ITEM_ID, TYPE_OF_CONTAINERSLOTS> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "container"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the container table
+     * @return Vector containing container table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract item ID from database row
+     * @param row Database result row
+     * @return Item ID from con_itemid column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_ITEM_ID override;
+
+    /**
+     * @brief Extract container slot count from database row
+     * @param row Database result row
+     * @return Number of slots from con_slots column
+     */
     auto assignTable(const Database::ResultTuple &row) -> TYPE_OF_CONTAINERSLOTS override;
 };
 

--- a/src/data/Data.hpp
+++ b/src/data/Data.hpp
@@ -37,30 +37,169 @@
 #include "data/TriggerTable.hpp"
 #include "data/WeaponObjectTable.hpp"
 
+/**
+ * @brief Central data management namespace
+ *
+ * Provides unified access to all game data tables through singleton instances.
+ * This namespace encapsulates:
+ * - Table instance management
+ * - Coordinated reload operations
+ * - Script reloading
+ * - Table activation after reload
+ *
+ * All tables are created as static instances and accessed via getter functions.
+ * This ensures single instances and provides a clean API for accessing game data.
+ *
+ * Typical reload workflow:
+ * 1. Call reload() or reloadTables()
+ * 2. Data loads into buffers without affecting active data
+ * 3. Call reloadScripts() to refresh Lua bindings
+ * 4. Call activateTables() to atomically swap in new data
+ */
 namespace Data {
 
+/**
+ * @brief Get script variables table
+ * @return Reference to singleton ScriptVariablesTable
+ */
 auto scriptVariables() -> ScriptVariablesTable &;
+
+/**
+ * @brief Get skills table
+ * @return Reference to singleton SkillTable
+ */
 auto skills() -> SkillTable &;
+
+/**
+ * @brief Get quests table
+ * @return Reference to singleton QuestTable
+ */
 auto quests() -> QuestTable &;
+
+/**
+ * @brief Get races table
+ * @return Reference to singleton RaceTable
+ */
 auto races() -> RaceTable &;
+
+/**
+ * @brief Get natural armors table
+ * @return Reference to singleton NaturalArmorTable
+ */
 auto naturalArmors() -> NaturalArmorTable &;
+
+/**
+ * @brief Get monster attacks table
+ * @return Reference to singleton MonsterAttackTable
+ */
 auto monsterAttacks() -> MonsterAttackTable &;
+
+/**
+ * @brief Get items table
+ * @return Reference to singleton ItemTable
+ */
 auto items() -> ItemTable &;
+
+/**
+ * @brief Get weapon items table
+ * @return Reference to singleton WeaponObjectTable
+ */
 auto weaponItems() -> WeaponObjectTable &;
+
+/**
+ * @brief Get armor items table
+ * @return Reference to singleton ArmorObjectTable
+ */
 auto armorItems() -> ArmorObjectTable &;
+
+/**
+ * @brief Get container items table
+ * @return Reference to singleton ContainerObjectTable
+ */
 auto containerItems() -> ContainerObjectTable &;
+
+/**
+ * @brief Get tiles modificator items table
+ * @return Reference to singleton TilesModificatorTable
+ */
 auto tilesModItems() -> TilesModificatorTable &;
+
+/**
+ * @brief Get tiles table
+ * @return Reference to singleton TilesTable
+ */
 auto tiles() -> TilesTable &;
+
+/**
+ * @brief Get spells table
+ * @return Reference to singleton SpellTable
+ */
 auto spells() -> SpellTable &;
+
+/**
+ * @brief Get triggers table
+ * @return Reference to singleton TriggerTable
+ */
 auto triggers() -> TriggerTable &;
+
+/**
+ * @brief Get long time effects table
+ * @return Reference to singleton LongTimeEffectTable
+ */
 auto longTimeEffects() -> LongTimeEffectTable &;
 
+/**
+ * @brief Get vector of all table pointers
+ * @return Vector containing pointers to all tables
+ */
 auto getTables() -> std::vector<Table *>;
+
+/**
+ * @brief Reload all tables from database into buffers
+ * @return true if all tables loaded successfully, false if any failed
+ */
 auto reloadTables() -> bool;
+
+/**
+ * @brief Reload all table scripts
+ *
+ * Refreshes Lua script bindings for all tables that have scripts.
+ */
 void reloadScripts();
+
+/**
+ * @brief Activate buffered data for all tables
+ *
+ * Atomically swaps buffered data into active storage for all tables,
+ * making newly loaded data live.
+ */
 void activateTables();
+
+/**
+ * @brief Complete reload: tables, scripts, and activation
+ *
+ * Convenience function that performs the full reload sequence:
+ * reloadTables() -> reloadScripts() -> activateTables()
+ *
+ * @return true if reload succeeded, false if any step failed
+ */
 auto reload() -> bool;
+
+/**
+ * @brief Prepare for reload (reserved for future use)
+ *
+ * Placeholder for pre-reload operations.
+ */
 void preReload();
+
+/**
+ * @brief Find item ID by name
+ *
+ * Searches the items table for an item with the given name.
+ *
+ * @param itemName Item name to search for
+ * @return Item ID if found, or 0 if not found
+ */
 auto getIdFromName(const std::string &itemName) -> TYPE_OF_ITEM_ID;
 
 } // namespace Data

--- a/src/data/ItemTable.hpp
+++ b/src/data/ItemTable.hpp
@@ -25,13 +25,63 @@
 #include "data/QuestScriptStructTable.hpp"
 #include "script/LuaItemScript.hpp"
 
+/**
+ * @brief Table for item definitions and properties
+ *
+ * Loads item data from the database "items" table, providing access to all
+ * item properties including:
+ * - Physical properties (volume, weight)
+ * - Aging/decay properties (aging speed, rot target, inventory decay)
+ * - Display properties (brightness)
+ * - Economic properties (worth, stack limits)
+ * - Localized names and descriptions
+ * - Rarity and level requirements
+ *
+ * Supports both main item scripts and quest-specific item scripts via the
+ * QuestScriptStructTable base class.
+ *
+ * Database table: items
+ * Script type: LuaItemScript
+ */
 class ItemTable : public QuestScriptStructTable<TYPE_OF_ITEM_ID, ItemStruct, LuaItemScript> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "items"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the items table
+     * @return Vector containing all item table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract item ID from database row
+     * @param row Database result row
+     * @return Item ID from itm_id column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_ITEM_ID override;
+
+    /**
+     * @brief Parse database row into ItemStruct
+     * @param row Database result row
+     * @return Populated ItemStruct with all item properties
+     */
     auto assignTable(const Database::ResultTuple &row) -> ItemStruct override;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename from itm_script column
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
+
+    /**
+     * @brief Get quest script nodes for items
+     * @return Iterator range over item quest nodes
+     */
     auto getQuestScripts() -> NodeRange override;
 
 private:

--- a/src/data/LongTimeEffectTable.hpp
+++ b/src/data/LongTimeEffectTable.hpp
@@ -25,12 +25,60 @@
 #include "data/ScriptStructTable.hpp"
 #include "script/LuaLongTimeEffectScript.hpp"
 
+/**
+ * @brief Table for long-term status effects and buffs/debuffs
+ *
+ * Loads long-time effect data from the database "longtimeeffects" table,
+ * defining persistent effects that can be applied to characters:
+ * - Buffs (stat boosts, damage shields, etc.)
+ * - Debuffs (poisons, curses, stat penalties)
+ * - Environmental effects (cold, heat, underwater)
+ * - Timed conditions (paralysis, sleep, confusion)
+ *
+ * Each effect has an ID, name, and associated Lua script that implements
+ * the effect's behavior (applying stat changes, dealing damage over time,
+ * handling removal conditions, etc.).
+ *
+ * Effects are applied to characters with a duration and can stack or
+ * be unique depending on script logic.
+ *
+ * Database table: longtimeeffects
+ * Columns: lte_effectid, lte_effectname, lte_scriptname
+ * Script type: LuaLongTimeEffectScript
+ */
 class LongTimeEffectTable : public ScriptStructTable<uint16_t, LongTimeEffectStruct, LuaLongTimeEffectScript> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "longtimeeffects"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the longtimeeffects table
+     * @return Vector containing effect table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract effect ID from database row
+     * @param row Database result row
+     * @return Effect ID from lte_effectid column
+     */
     auto assignId(const Database::ResultTuple &row) -> uint16_t override;
+
+    /**
+     * @brief Parse database row into LongTimeEffectStruct
+     * @param row Database result row
+     * @return Populated LongTimeEffectStruct with effect ID and name
+     */
     auto assignTable(const Database::ResultTuple &row) -> LongTimeEffectStruct override;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename from lte_scriptname column
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
 };
 

--- a/src/data/MonsterAttackTable.hpp
+++ b/src/data/MonsterAttackTable.hpp
@@ -23,17 +23,61 @@
 
 #include "data/StructTable.hpp"
 
+/**
+ * @brief Attack bonus data for monster races
+ *
+ * Defines special attack properties that modify a monster's combat behavior
+ * beyond base weapon stats.
+ */
 struct AttackBoni {
-    uint8_t attackType = 0;
-    int16_t attackValue = 0;
-    int16_t actionPointsLost = 0;
+    uint8_t attackType = 0;         ///< Type of special attack (bite, claw, magic, etc.)
+    int16_t attackValue = 0;        ///< Bonus/penalty to attack roll
+    int16_t actionPointsLost = 0;   ///< Action point cost for this attack
 };
 
+/**
+ * @brief Table for monster race-specific attack bonuses
+ *
+ * Loads monster attack data from the database "monsterattack" table, defining
+ * special combat abilities and modifiers for different monster races. Each
+ * race can have unique attack types with their own bonuses:
+ * - Natural weapons (claws, fangs, stingers)
+ * - Special attack forms (breath weapons, magical attacks)
+ * - Attack roll modifiers
+ * - Action point costs
+ *
+ * This supplements weapon data to give monsters distinctive combat styles
+ * based on their race/type rather than just equipped items.
+ *
+ * Database table: monsterattack
+ * Columns: mat_race_type, mat_attack_type, mat_attack_value, mat_actionpointslost
+ */
 class MonsterAttackTable : public StructTable<uint16_t, AttackBoni> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "monsterattack"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the monsterattack table
+     * @return Vector containing monster attack column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract race type ID from database row
+     * @param row Database result row
+     * @return Race type ID from mat_race_type column
+     */
     auto assignId(const Database::ResultTuple &row) -> uint16_t override;
+
+    /**
+     * @brief Parse database row into AttackBoni
+     * @param row Database result row
+     * @return Populated AttackBoni with attack properties
+     */
     auto assignTable(const Database::ResultTuple &row) -> AttackBoni override;
 };
 

--- a/src/data/MonsterTable.hpp
+++ b/src/data/MonsterTable.hpp
@@ -26,18 +26,57 @@
 #include <TableStructs.hpp>
 #include <boost/unordered_map.hpp>
 
+/**
+ * @brief Table for monster type definitions and scripts
+ *
+ * Loads monster data from the database "monster" table, providing access to
+ * monster properties including:
+ * - Names (German and English)
+ * - Race and appearance properties (size range)
+ * - Combat properties (HP, attack capability, self-healing)
+ * - Movement type
+ * - Associated Lua scripts for behavior
+ *
+ * This table uses the older direct database loading approach rather than
+ * inheriting from StructTable. Monster scripts are loaded directly and
+ * quest scripts are integrated during construction.
+ *
+ * Database table: monster
+ */
 class MonsterTable {
 public:
+    /**
+     * @brief Constructor - loads monster data and scripts from database
+     *
+     * Queries the monster table and loads all monster definitions along with
+     * their associated scripts. Also loads quest scripts from QuestNodeTable.
+     */
     MonsterTable();
 
+    /**
+     * @brief Check if table data loaded successfully
+     * @return true if data is valid, false if loading failed
+     */
     [[nodiscard]] inline auto isDataOK() const -> bool { return dataOK; }
 
+    /**
+     * @brief Check if monster type exists
+     * @param id Monster type ID
+     * @return true if monster exists, false otherwise
+     */
     [[nodiscard]] auto exists(TYPE_OF_CHARACTER_ID id) const -> bool;
+
+    /**
+     * @brief Access monster data by ID
+     * @param id Monster type ID
+     * @return Const reference to MonsterStruct
+     * @note Creates default entry if ID not found
+     */
     auto operator[](TYPE_OF_CHARACTER_ID id) -> const MonsterStruct &;
 
 private:
     using TABLE = boost::unordered_map<TYPE_OF_CHARACTER_ID, MonsterStruct>;
-    TABLE table;
-    bool dataOK = false;
+    TABLE table;     ///< Map of monster ID to monster data
+    bool dataOK = false;  ///< Whether data loaded successfully
 };
 #endif

--- a/src/data/NPCTable.hpp
+++ b/src/data/NPCTable.hpp
@@ -30,28 +30,68 @@
 
 class World;
 
+/**
+ * @brief Data structure for NPC spawn definition
+ *
+ * Contains all information needed to spawn an NPC in the world,
+ * including position, appearance, behavior, and associated scripts.
+ */
 struct NPCStruct {
-    position NPCPos;
-    std::string Name;
-    TYPE_OF_RACE_ID type;
-    Character::face_to faceto;
-    std::vector<struct NPCTalk> speechTexts;
-    unsigned short int walk_range;
-    bool ishealer;
+    position NPCPos;                            ///< Spawn position in world
+    std::string Name;                           ///< NPC name
+    TYPE_OF_RACE_ID type;                       ///< Race/appearance type
+    Character::face_to faceto;                  ///< Initial facing direction
+    std::vector<struct NPCTalk> speechTexts;    ///< Pre-defined speech texts
+    unsigned short int walk_range;              ///< Maximum wander distance from spawn
+    bool ishealer;                              ///< Whether NPC can heal players
 };
 
+/**
+ * @brief Table for NPC spawn definitions and instantiation
+ *
+ * Loads NPC spawn data from the database "npc" table and creates NPC
+ * instances in the world. Each entry defines:
+ * - Position and facing direction
+ * - Name and race
+ * - Appearance details (hair, beard, skin color)
+ * - Behavior flags (healer status)
+ * - Associated Lua scripts
+ *
+ * Unlike other tables, NPCTable directly instantiates NPC characters in the
+ * world during construction rather than just storing definitions. It also
+ * loads quest scripts from QuestNodeTable.
+ *
+ * @note The reload mechanism needs refactoring (see TODO in implementation)
+ *
+ * Database table: npc
+ */
 class NPCTable {
 public:
+    /**
+     * @brief Constructor - loads and spawns all NPCs
+     *
+     * Queries the npc table, creates NPC character instances, and adds them
+     * to the world. Also loads and assigns NPC scripts including quest scripts.
+     */
     NPCTable();
 
+    /**
+     * @brief Check if NPC data loaded successfully
+     * @return true if data is valid, false if loading failed
+     */
     [[nodiscard]] auto dataOK() const -> bool { return m_dataOK; };
 
 private:
+    /**
+     * @brief Load NPC data and spawn NPCs in world
+     *
+     * Queries database, creates NPC instances, and populates the world.
+     */
     void reload();
-    bool m_dataOK{};
 
-    World *_world;
-    std::list<struct NPCStruct> NPCList;
+    bool m_dataOK{};                        ///< Whether data loaded successfully
+    World *_world;                          ///< Pointer to game world
+    std::list<struct NPCStruct> NPCList;    ///< List of NPC definitions (currently unused)
 };
 
 #endif

--- a/src/data/NaturalArmorTable.hpp
+++ b/src/data/NaturalArmorTable.hpp
@@ -24,11 +24,51 @@
 #include "TableStructs.hpp"
 #include "data/StructTable.hpp"
 
+/**
+ * @brief Table for race-based natural armor values
+ *
+ * Loads natural armor data from the database "naturalarmor" table, defining
+ * the innate defensive properties of different races. Natural armor represents
+ * physical resistance that comes from a race's body (thick skin, scales, fur,
+ * exoskeleton, etc.) rather than worn equipment.
+ *
+ * Each race has armor values against three damage types:
+ * - Stroke armor (defense against slashing attacks)
+ * - Puncture armor (defense against piercing attacks)
+ * - Thrust armor (defense against thrusting attacks)
+ *
+ * These values are primarily used for monsters but can apply to any race.
+ * Natural armor stacks with or modifies worn armor depending on game rules.
+ *
+ * Database table: naturalarmor
+ * Columns: nar_race, nar_strokearmor, nar_puncturearmor, nar_thrustarmor
+ */
 class NaturalArmorTable : public StructTable<uint16_t, MonsterArmor> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "naturalarmor"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the naturalarmor table
+     * @return Vector containing natural armor column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract race ID from database row
+     * @param row Database result row
+     * @return Race ID from nar_race column
+     */
     auto assignId(const Database::ResultTuple &row) -> uint16_t override;
+
+    /**
+     * @brief Parse database row into MonsterArmor
+     * @param row Database result row
+     * @return Populated MonsterArmor with armor values for all damage types
+     */
     auto assignTable(const Database::ResultTuple &row) -> MonsterArmor override;
 };
 

--- a/src/data/QuestNodeTable.hpp
+++ b/src/data/QuestNodeTable.hpp
@@ -32,37 +32,71 @@
 
 class LuaScript;
 
+/**
+ * @brief Quest script attachment point
+ *
+ * Represents a script function that should be called when a quest-related
+ * event occurs on a specific entity (item, NPC, monster, or trigger).
+ */
 struct NodeStruct {
-    std::string entrypoint;
-    std::shared_ptr<LuaScript> script;
+    std::string entrypoint;             ///< Function name to call in the script
+    std::shared_ptr<LuaScript> script;  ///< Loaded Lua script instance
 };
 
+/**
+ * @brief Singleton table for quest script attachments to game entities
+ *
+ * Manages quest-related script bindings loaded from quest.txt files in the
+ * questsystem directory. Quest scripts can be attached to:
+ * - Items (use item, move item, etc.)
+ * - NPCs (talk to NPC, trade with NPC)
+ * - Monsters (kill monster, loot monster)
+ * - Trigger fields (enter trigger location)
+ *
+ * Each quest directory contains a quest.txt file defining script attachments:
+ * - Format: type, id, function, script (or x, y, z, function, script for triggers)
+ * - Multiple scripts can attach to the same entity
+ * - Scripts are called in addition to the entity's main scripts
+ *
+ * This enables modular quest implementation where quest-specific behavior
+ * is added without modifying core entity scripts.
+ *
+ * @note Singleton pattern - access via getInstance()
+ * @note Loads from filesystem, not database
+ */
 class QuestNodeTable {
 private:
     template <typename Key> using Table = std::unordered_multimap<Key, NodeStruct>;
     template <typename Key> using TableIterator = typename Table<Key>::const_iterator;
 
     static std::unique_ptr<QuestNodeTable> instance;
-    Table<TYPE_OF_ITEM_ID> itemNodes;
-    Table<unsigned int> npcNodes;
-    Table<unsigned int> monsterNodes;
-    Table<position> triggerNodes;
+    Table<TYPE_OF_ITEM_ID> itemNodes;     ///< Quest scripts attached to items
+    Table<unsigned int> npcNodes;          ///< Quest scripts attached to NPCs
+    Table<unsigned int> monsterNodes;      ///< Quest scripts attached to monsters
+    Table<position> triggerNodes;          ///< Quest scripts attached to trigger positions
 
-    static constexpr auto normalEntryCount = 4;
-    static constexpr auto triggerfieldEntryCount = 6;
+    static constexpr auto normalEntryCount = 4;         ///< Expected fields for item/NPC/monster
+    static constexpr auto triggerfieldEntryCount = 6;   ///< Expected fields for triggers
 
-    static constexpr auto typePosition = 0;
-    static constexpr auto idPosition = 1;
-    static constexpr auto functionPosition = 2;
-    static constexpr auto scriptPosition = 3;
-    static constexpr auto triggerCoordinateXPosition = 1;
-    static constexpr auto triggerCoordinateYPosition = 2;
-    static constexpr auto triggerCoordinateZPosition = 3;
-    static constexpr auto triggerFunctionPosition = 4;
-    static constexpr auto triggerScriptPosition = 5;
+    static constexpr auto typePosition = 0;                   ///< Entry type field index
+    static constexpr auto idPosition = 1;                     ///< Entity ID field index
+    static constexpr auto functionPosition = 2;               ///< Function name field index
+    static constexpr auto scriptPosition = 3;                 ///< Script filename field index
+    static constexpr auto triggerCoordinateXPosition = 1;     ///< Trigger X coordinate field index
+    static constexpr auto triggerCoordinateYPosition = 2;     ///< Trigger Y coordinate field index
+    static constexpr auto triggerCoordinateZPosition = 3;     ///< Trigger Z coordinate field index
+    static constexpr auto triggerFunctionPosition = 4;        ///< Trigger function field index
+    static constexpr auto triggerScriptPosition = 5;          ///< Trigger script field index
 
 public:
+    /**
+     * @brief Constructor - loads quest node data from filesystem
+     *
+     * Scans questsystem directory for quest.txt files and loads all
+     * quest script attachments.
+     */
     QuestNodeTable();
+
     QuestNodeTable(const QuestNodeTable &) = delete;
     auto operator=(const QuestNodeTable &) -> QuestNodeTable & = delete;
     QuestNodeTable(QuestNodeTable &&) = delete;
@@ -71,15 +105,54 @@ public:
 
     template <typename Key> using TableRange = std::pair<TableIterator<Key>, TableIterator<Key>>;
 
+    /**
+     * @brief Get singleton instance
+     * @return Reference to the singleton instance
+     */
     static auto getInstance() -> QuestNodeTable &;
+
+    /**
+     * @brief Reload all quest node data from filesystem
+     *
+     * Clears existing data and rescans questsystem directory.
+     */
     void reload();
+
+    /**
+     * @brief Get all quest scripts attached to items
+     * @return Iterator range over item quest nodes
+     */
     auto getItemNodes() const -> TableRange<TYPE_OF_ITEM_ID>;
+
+    /**
+     * @brief Get all quest scripts attached to NPCs
+     * @return Iterator range over NPC quest nodes
+     */
     auto getNpcNodes() const -> TableRange<unsigned int>;
+
+    /**
+     * @brief Get all quest scripts attached to monsters
+     * @return Iterator range over monster quest nodes
+     */
     auto getMonsterNodes() const -> TableRange<unsigned int>;
+
+    /**
+     * @brief Get all quest scripts attached to trigger positions
+     * @return Iterator range over trigger quest nodes
+     */
     auto getTriggerNodes() const -> TableRange<position>;
 
 private:
+    /**
+     * @brief Parse a quest.txt file and load its attachments
+     * @param questFile Open file stream for quest.txt
+     * @param questPath Path to quest directory
+     */
     void readQuest(std::ifstream &questFile, std::filesystem::path &questPath);
+
+    /**
+     * @brief Clear all quest node data
+     */
     void clear();
 };
 

--- a/src/data/QuestScriptStructTable.hpp
+++ b/src/data/QuestScriptStructTable.hpp
@@ -25,11 +25,37 @@
 #include "data/QuestNodeTable.hpp"
 #include "data/ScriptStructTable.hpp"
 
+/**
+ * @brief Extension of ScriptStructTable that adds quest script support
+ *
+ * Extends ScriptStructTable to support quest-related scripts in addition to
+ * the main item/NPC scripts. Quest scripts are loaded from the QuestNodeTable
+ * and added to the script stack using addQuestScript().
+ *
+ * This allows items, NPCs, etc. to have both:
+ * - A primary script (from the main table)
+ * - Additional quest scripts (from quest nodes)
+ *
+ * Quest scripts are typically used to add quest-specific behavior without
+ * modifying the main script.
+ *
+ * @tparam IdType Type of the unique identifier
+ * @tparam StructType Type of the data structure stored
+ * @tparam ScriptType Type of Lua script that supports quest scripts
+ * @tparam ScriptParameter Type passed to script constructor (defaults to StructType)
+ */
 template <typename IdType, typename StructType, typename ScriptType, typename ScriptParameter = StructType>
 class QuestScriptStructTable : public ScriptStructTable<IdType, StructType, ScriptType, ScriptParameter> {
 public:
     using Base = ScriptStructTable<IdType, StructType, ScriptType, ScriptParameter>;
 
+    /**
+     * @brief Load both main scripts and quest scripts
+     *
+     * First calls base class to load main scripts, then adds quest scripts
+     * from the quest node table. Creates script objects if they don't exist
+     * yet (for items/NPCs that only have quest scripts).
+     */
     void reloadScripts() override {
         Base::reloadScripts();
         auto questNodes = getQuestScripts();
@@ -62,6 +88,10 @@ protected:
     using Base::getColumnNames;
     using Base::getTableName;
 
+    /**
+     * @brief Get quest script nodes for this table's entries
+     * @return Iterator range over quest nodes relevant to this table
+     */
     virtual auto getQuestScripts() -> NodeRange = 0;
 };
 

--- a/src/data/QuestTable.hpp
+++ b/src/data/QuestTable.hpp
@@ -27,26 +27,99 @@
 
 #include <map>
 
+/**
+ * @brief Empty struct for quest data (all data is in scripts)
+ *
+ * Quest logic is entirely implemented in Lua scripts, so no
+ * additional data structure is needed in C++.
+ */
 struct QuestStruct {};
 
+/**
+ * @brief Table for quest definitions and quest scripts
+ *
+ * Loads quest data from the database "quests" table, managing the questing
+ * system including:
+ * - Quest definitions and IDs
+ * - Quest scripts implementing quest logic
+ * - Quest start locations for proximity detection
+ * - Spatial indexing for finding nearby quests
+ *
+ * Each quest has a start position (defined in its Lua script) that determines
+ * where it becomes available to players. The table maintains a spatial index
+ * for efficient lookup of quests within range of a player's position.
+ *
+ * @note ScriptParameter is TYPE_OF_QUEST_ID (not QuestStruct), so scripts
+ *       are constructed with quest ID only
+ *
+ * Database table: quests
+ * Columns: qst_id, qst_script
+ * Script type: LuaQuestScript
+ */
 class QuestTable : public ScriptStructTable<TYPE_OF_QUEST_ID, QuestStruct, LuaQuestScript, TYPE_OF_QUEST_ID> {
 private:
     using Base = ScriptStructTable<TYPE_OF_QUEST_ID, QuestStruct, LuaQuestScript, TYPE_OF_QUEST_ID>;
     using quest_starts_type = std::multimap<position, TYPE_OF_QUEST_ID, PositionComparison>;
 
 public:
+    /**
+     * @brief Get database table name
+     * @return "quests"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the quests table
+     * @return Vector containing quest table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract quest ID from database row
+     * @param row Database result row
+     * @return Quest ID from qst_id column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_QUEST_ID override;
+
+    /**
+     * @brief Parse database row into QuestStruct
+     * @param row Database result row
+     * @return Empty QuestStruct (no data stored)
+     */
     auto assignTable(const Database::ResultTuple &row) -> QuestStruct override;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename from qst_script column
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
+
+    /**
+     * @brief Reload scripts and build spatial index of quest starts
+     *
+     * After loading quest scripts, queries each script for its start position
+     * and builds a spatial index for efficient proximity queries.
+     */
     void reloadScripts() override;
 
     using QuestStartMap = std::map<TYPE_OF_QUEST_ID, position>;
+
+    /**
+     * @brief Find quests within range of a position
+     *
+     * Uses the spatial index to efficiently find all quests whose start
+     * positions are within the specified radius of the given position.
+     * Uses Manhattan distance (|dx| + |dy|) for the 2D check.
+     *
+     * @param pos Center position to search from
+     * @param radius Maximum distance (in tiles) from center
+     * @return Map of quest IDs to their start positions within range
+     */
     auto getQuestsInRange(const position &pos, Coordinate radius) const -> QuestStartMap;
 
 private:
-    quest_starts_type questStarts;
+    quest_starts_type questStarts;  ///< Spatial index: position -> quest IDs
 };
 
 #endif

--- a/src/data/RaceTable.hpp
+++ b/src/data/RaceTable.hpp
@@ -25,15 +25,82 @@
 #include "data/StructTable.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for character race definitions and attribute limits
+ *
+ * Loads race data from the database "race" table, defining playable races
+ * with their physical characteristics (height) and attribute constraints.
+ * Each race has minimum and maximum values for all character attributes,
+ * used for character creation validation.
+ *
+ * Provides helper methods for:
+ * - Calculating relative size scaling (80-120% based on height)
+ * - Validating attributes are within racial limits
+ * - Retrieving maximum attribute points for character creation
+ */
 class RaceTable : public StructTable<uint16_t, RaceStruct> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "race"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the race table
+     * @return Vector containing race table column names (race_id, race_name, height ranges, attribute ranges)
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract race ID from database row
+     * @param row Database result row
+     * @return Race ID from race_id column
+     */
     auto assignId(const Database::ResultTuple &row) -> uint16_t override;
+
+    /**
+     * @brief Parse database row into RaceStruct
+     * @param row Database result row
+     * @return Populated RaceStruct with name, size, and attribute limits
+     */
     auto assignTable(const Database::ResultTuple &row) -> RaceStruct override;
+
+    /**
+     * @brief Calculate relative size percentage for a race and height
+     *
+     * Converts absolute height to relative size scaling (80-120%) using
+     * linear interpolation between the race's min and max height.
+     *
+     * @param race Race ID to check
+     * @param size Absolute character height/size
+     * @return Relative size percentage (80-120), or 100 if race not found or size is 0
+     */
     auto getRelativeSize(TYPE_OF_RACE_ID race, uint16_t size) const -> uint8_t;
+
+    /**
+     * @brief Check if attribute value is within racial limits
+     *
+     * Validates that the given attribute value falls within the min/max
+     * range defined for the race.
+     *
+     * @param race Race ID to check
+     * @param attribute Which attribute to validate (agility, strength, etc.)
+     * @param value Attribute value to check
+     * @return true if value is within limits, false otherwise
+     */
     auto isBaseAttributeInLimits(TYPE_OF_RACE_ID race, Character::attributeIndex attribute,
                                  Attribute::attribute_t value) const -> bool;
+
+    /**
+     * @brief Get maximum attribute points for character creation
+     *
+     * Returns the total number of attribute points a character of this race
+     * can distribute during character creation.
+     *
+     * @param race Race ID to check
+     * @return Maximum attribute points, or 0 if race not found
+     */
     auto getMaxAttributePoints(TYPE_OF_RACE_ID race) const -> uint8_t;
 };
 

--- a/src/data/RaceTypeTable.hpp
+++ b/src/data/RaceTypeTable.hpp
@@ -27,25 +27,87 @@
 #include <map>
 #include <vector>
 
+/**
+ * @brief Table for race appearance variations (subtypes)
+ *
+ * Loads race subtype data from multiple database tables (race_types, race_hair,
+ * race_beard, race_hair_colour, race_skin_colour), defining available appearance
+ * options for each race and subtype combination.
+ *
+ * Each race (human, dwarf, elf, etc.) can have multiple subtypes representing
+ * different ethnicities or variants, each with their own sets of:
+ * - Available hairstyles
+ * - Available beard styles (if applicable)
+ * - Available hair colors
+ * - Available skin colors
+ *
+ * This data is used for:
+ * - Character creation (offering valid appearance options)
+ * - Validating character appearance
+ * - Generating random NPCs with appropriate appearances
+ *
+ * @note Uses older direct database loading rather than StructTable
+ *
+ * Database tables: race_types, race_hair, race_beard, race_hair_colour, race_skin_colour
+ */
 class RaceTypeTable {
 public:
+    /**
+     * @brief Constructor - loads race subtype data from database
+     *
+     * Queries multiple database tables to build the complete mapping of
+     * race/subtype combinations to appearance options.
+     */
     RaceTypeTable();
 
+    /**
+     * @brief Check if table data loaded successfully
+     * @return true if data is valid, false if loading failed
+     */
     [[nodiscard]] inline auto isDataOK() const -> bool { return dataOK; }
 
+    /**
+     * @brief Get a random valid appearance configuration for a race
+     *
+     * Selects a random subtype and generates random appearance values
+     * (hairstyle, beard, colors) appropriate for that race.
+     *
+     * @param race Race ID to generate configuration for
+     * @return Random RaceConfiguration with valid appearance options
+     */
     [[nodiscard]] auto getRandomRaceConfiguration(TYPE_OF_RACE_ID race) const -> RaceConfiguration;
+
+    /**
+     * @brief Check if a hairstyle is valid for a race/subtype
+     * @param race Race ID
+     * @param type Subtype ID
+     * @param hair Hairstyle ID
+     * @return true if hairstyle is available, false otherwise
+     */
     [[nodiscard]] auto isHairAvailable(TYPE_OF_RACE_ID race, TYPE_OF_RACE_TYPE_ID type, uint16_t hair) const -> bool;
+
+    /**
+     * @brief Check if a beard style is valid for a race/subtype
+     * @param race Race ID
+     * @param type Subtype ID
+     * @param beard Beard style ID
+     * @return true if beard style is available, false otherwise
+     */
     [[nodiscard]] auto isBeardAvailable(TYPE_OF_RACE_ID race, TYPE_OF_RACE_TYPE_ID type, uint16_t beard) const -> bool;
 
 private:
+    /**
+     * @brief Appearance options for a specific race subtype
+     */
     struct RaceTypeStruct {
-        std::vector<uint16_t> hair;
-        std::vector<uint16_t> beard;
-        std::vector<Colour> hairColour;
-        std::vector<Colour> skinColour;
+        std::vector<uint16_t> hair;         ///< Available hairstyle IDs
+        std::vector<uint16_t> beard;        ///< Available beard style IDs
+        std::vector<Colour> hairColour;     ///< Available hair colors
+        std::vector<Colour> skinColour;     ///< Available skin colors
     };
+
     using TABLE = std::map<TYPE_OF_RACE_ID, std::map<TYPE_OF_RACE_TYPE_ID, RaceTypeStruct>>;
-    TABLE table;
-    bool dataOK = false;
+    TABLE table;            ///< Nested map: race -> subtype -> appearance options
+    bool dataOK = false;    ///< Whether data loaded successfully
 };
 #endif

--- a/src/data/ScheduledScriptsTable.hpp
+++ b/src/data/ScheduledScriptsTable.hpp
@@ -32,38 +32,106 @@
 
 class World;
 
+/**
+ * @brief Data for a scheduled script execution
+ *
+ * Contains all timing and identification information for a script that
+ * runs periodically on the server.
+ */
 struct ScriptData {
-    uint32_t minCycleTime = 0;
-    uint32_t maxCycleTime = 0;
-    uint32_t nextCycleTime = 0;
-    uint32_t lastCycleTime = 0;
-    std::string functionName;
-    std::string scriptName;
-    std::shared_ptr<LuaScheduledScript> scriptptr;
+    uint32_t minCycleTime = 0;      ///< Minimum cycles between executions
+    uint32_t maxCycleTime = 0;      ///< Maximum cycles between executions
+    uint32_t nextCycleTime = 0;     ///< Next cycle when script should run
+    uint32_t lastCycleTime = 0;     ///< Last cycle when script ran
+    std::string functionName;       ///< Lua function to call
+    std::string scriptName;         ///< Script filename
+    std::shared_ptr<LuaScheduledScript> scriptptr;  ///< Loaded script instance
 
     ScriptData() = default;
+
+    /**
+     * @brief Construct script data with all parameters
+     * @param minCT Minimum cycle time
+     * @param maxCT Maximum cycle time
+     * @param nextCT Next execution cycle
+     * @param lastCT Last execution cycle
+     * @param fname Function name to call
+     * @param sname Script filename
+     */
     ScriptData(uint32_t minCT, uint32_t maxCT, uint32_t nextCT, uint32_t lastCT, std::string fname, std::string sname)
             : minCycleTime(minCT), maxCycleTime(maxCT), nextCycleTime(nextCT), lastCycleTime(lastCT),
               functionName(std::move(fname)), scriptName(std::move(sname)) {}
 };
 
+/**
+ * @brief Table for periodically executed scripts
+ *
+ * Loads and manages scripts that run on a schedule from the database
+ * "scheduledscripts" table. Scheduled scripts enable:
+ * - World maintenance tasks (cleanup, spawning)
+ * - Periodic events (day/night cycle, weather)
+ * - Timed game mechanics (regeneration, decay)
+ * - Background processes (economy updates, NPC behavior)
+ *
+ * Scripts are stored in a priority queue sorted by next execution time.
+ * Each cycle (game tick), due scripts are executed and rescheduled with
+ * a random interval between min and max cycle time.
+ *
+ * @note Uses older direct database loading rather than StructTable
+ * @note Limited to 200 script executions per cycle to prevent runaway execution
+ *
+ * Database table: scheduledscripts
+ */
 class ScheduledScriptsTable {
 public:
+    /**
+     * @brief Constructor - loads scheduled scripts from database
+     *
+     * Queries the scheduledscripts table and loads all scripts with their
+     * timing parameters.
+     */
     ScheduledScriptsTable();
 
+    /**
+     * @brief Check if table data loaded successfully
+     * @return true if data is valid, false if loading failed
+     */
     [[nodiscard]] inline auto isDataOK() const -> bool { return m_dataOk; }
 
+    /**
+     * @brief Advance to next cycle and execute due scripts
+     *
+     * Increments the cycle counter, executes all scripts whose nextCycleTime
+     * has been reached, and reschedules them with a new random interval.
+     * Limited to 200 executions per cycle for safety.
+     */
     void nextCycle();
 
+    /**
+     * @brief Add or reschedule a script in the execution queue
+     *
+     * Inserts script into the queue at the appropriate position based on
+     * its nextCycleTime, maintaining sorted order.
+     *
+     * @param data Script data to add
+     */
     void addData(const ScriptData &data);
 
 private:
+    /**
+     * @brief Load scheduled scripts from database
+     *
+     * Called by constructor to populate the script list.
+     */
     void reload();
 
-    std::list<ScriptData> m_table;
-    uint32_t currentCycle{0};
-    bool m_dataOk{false};
+    std::list<ScriptData> m_table;  ///< Sorted list of scheduled scripts
+    uint32_t currentCycle{0};       ///< Current server cycle/tick count
+    bool m_dataOk{false};           ///< Whether data loaded successfully
 
+    /**
+     * @brief Clear old table data before reload
+     */
     void clearOldTable();
 };
 #endif

--- a/src/data/ScriptStructTable.hpp
+++ b/src/data/ScriptStructTable.hpp
@@ -31,12 +31,34 @@
 
 namespace detail {
 
+/**
+ * @brief Helper function to create scripts with StructType parameter
+ * @tparam IdType ID type
+ * @tparam StructType Data structure type
+ * @tparam ScriptType Script type
+ * @param scripts Map to store created script
+ * @param id Entry ID
+ * @param name Script filename
+ * @param data Data structure for script
+ * @param dummy Type discriminator (StructType)
+ */
 template <typename IdType, typename StructType, typename ScriptType>
 void detailAssign(std::unordered_map<IdType, std::shared_ptr<ScriptType>> &scripts, const IdType &id,
                   const std::string &name, const StructType &data, const StructType &dummy) {
     scripts.emplace(id, std::make_shared<ScriptType>(name, data));
 }
 
+/**
+ * @brief Helper function to create scripts with IdType parameter
+ * @tparam IdType ID type
+ * @tparam StructType Data structure type
+ * @tparam ScriptType Script type
+ * @param scripts Map to store created script
+ * @param id Entry ID
+ * @param name Script filename
+ * @param data Data structure (unused in this overload)
+ * @param dummy Type discriminator (IdType)
+ */
 template <typename IdType, typename StructType, typename ScriptType>
 void detailAssign(std::unordered_map<IdType, std::shared_ptr<ScriptType>> &scripts, const IdType &id,
                   const std::string &name, const StructType &data, const IdType &dummy) {
@@ -45,11 +67,34 @@ void detailAssign(std::unordered_map<IdType, std::shared_ptr<ScriptType>> &scrip
 
 } // namespace detail
 
+/**
+ * @brief Template table class for data with associated Lua scripts
+ *
+ * Extends StructTable to support loading and managing Lua scripts associated
+ * with table entries. Each entry can have an optional script that implements
+ * custom behavior (e.g., item use scripts, NPC scripts).
+ *
+ * Scripts are loaded during reloadScripts() by reading script filenames from
+ * the database and instantiating the appropriate script objects. The
+ * ScriptParameter template parameter determines what gets passed to the
+ * script constructor - either the full data structure or just the ID.
+ *
+ * @tparam IdType Type of the unique identifier
+ * @tparam StructType Type of the data structure stored
+ * @tparam ScriptType Type of Lua script (e.g., LuaItemScript, LuaNPCScript)
+ * @tparam ScriptParameter Type passed to script constructor (defaults to StructType)
+ */
 template <typename IdType, typename StructType, typename ScriptType, typename ScriptParameter = StructType>
 class ScriptStructTable : public StructTable<IdType, StructType> {
 public:
     using Base = StructTable<IdType, StructType>;
 
+    /**
+     * @brief Load and compile Lua scripts for table entries
+     *
+     * Instantiates script objects for all entries that have script files
+     * defined. Clears any previously loaded scripts first.
+     */
     void reloadScripts() override {
         scripts.clear();
 
@@ -69,6 +114,11 @@ public:
         scriptNames.clear();
     }
 
+    /**
+     * @brief Get the script for a specific entry
+     * @param id Entry ID
+     * @return Shared pointer to script, or nullptr if no script exists
+     */
     auto script(IdType id) const -> std::shared_ptr<ScriptType> {
         auto it = scripts.find(id);
 
@@ -83,8 +133,18 @@ protected:
     using Base::assignTable;
     using Base::getColumnNames;
     using Base::getTableName;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename, or empty string if no script
+     */
     virtual auto assignScriptName(const Database::ResultTuple &row) -> std::string = 0;
 
+    /**
+     * @brief Process database row, extracting both data and script name
+     * @param row Database result row
+     */
     void evaluateRow(const Database::ResultTuple &row) override {
         Base::evaluateRow(row);
         std::string scriptName = assignScriptName(row);
@@ -94,6 +154,11 @@ protected:
         }
     }
 
+    /**
+     * @brief Get mutable reference to script (for derived classes)
+     * @param id Entry ID
+     * @return Mutable reference to script shared pointer
+     */
     auto scriptNonConst(IdType id) -> std::shared_ptr<ScriptType> & { return scripts[id]; }
 
 private:
@@ -102,10 +167,17 @@ private:
     template <typename T> void internalAssign(const IdType &id, const std::string &name, const StructType &data);
 
     using NamesType = std::vector<std::pair<IdType, std::string>>;
-    NamesType scriptNames;
-    ScriptsType scripts;
+    NamesType scriptNames;  ///< Script filenames collected during buffer load
+    ScriptsType scripts;    ///< Active script instances indexed by ID
 };
 
+/**
+ * @brief Internal helper to create script with appropriate parameters
+ * @tparam T Type discriminator for overload resolution
+ * @param id Entry ID
+ * @param name Script filename
+ * @param data Data structure
+ */
 template <typename IdType, typename StructType, typename ScriptType, typename ScriptParameter>
 template <typename T>
 void ScriptStructTable<IdType, StructType, ScriptType, ScriptParameter>::internalAssign(const IdType &id,

--- a/src/data/ScriptVariablesTable.hpp
+++ b/src/data/ScriptVariablesTable.hpp
@@ -23,26 +23,109 @@
 
 #include "data/StructTable.hpp"
 
+/**
+ * @brief Table for persistent script-accessible variables
+ *
+ * Loads and manages persistent key-value pairs from the database "scriptvariables"
+ * table that can be read and written by Lua scripts. This provides:
+ * - Cross-session persistence of script state
+ * - Global variables accessible to all scripts
+ * - String-based key-value storage
+ * - Database-backed persistence
+ *
+ * Scripts can use this to store:
+ * - World state (event progress, timers)
+ * - Global counters and flags
+ * - Cross-player shared data
+ * - Quest progression markers
+ *
+ * Unlike other tables, this supports write operations (set/remove) and
+ * changes are saved back to the database.
+ *
+ * Database table: scriptvariables
+ * Columns: svt_ids (key), svt_string (value)
+ */
 class ScriptVariablesTable : public StructTable<std::string, std::string> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "scriptvariables"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the scriptvariables table
+     * @return Vector containing column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract variable key from database row
+     * @param row Database result row
+     * @return Variable key from svt_ids column
+     */
     auto assignId(const Database::ResultTuple &row) -> std::string override;
+
+    /**
+     * @brief Extract variable value from database row
+     * @param row Database result row
+     * @return Variable value from svt_string column
+     */
     auto assignTable(const Database::ResultTuple &row) -> std::string override;
 
+    /**
+     * @brief Find a variable by key
+     * @param id Variable key to find
+     * @param ret Output parameter for the value
+     * @return true if variable exists, false otherwise
+     */
     auto find(const std::string &id, std::string &ret) -> bool;
+
+    /**
+     * @brief Set a string variable value
+     * @param id Variable key
+     * @param value String value to store
+     */
     void set(const std::string &id, const std::string &value);
+
+    /**
+     * @brief Set an integer variable value (converted to string)
+     * @param id Variable key
+     * @param value Integer value to store
+     */
     void set(const std::string &id, int32_t value);
+
+    /**
+     * @brief Remove a variable
+     * @param id Variable key to remove
+     * @return true if variable was removed, false if not found
+     */
     auto remove(const std::string &id) -> bool;
 
+    /**
+     * @brief Save all changes to database
+     *
+     * Writes modified variables back to the database. Called periodically
+     * or on server shutdown to persist changes.
+     */
     void save();
 
+    /**
+     * @brief Reload variables from database
+     * @return true if reload succeeded, false otherwise
+     */
     auto reloadBuffer() -> bool override;
+
+    /**
+     * @brief Activate buffered data
+     *
+     * Special handling for first load to avoid clearing modified data.
+     */
     void activateBuffer() override;
 
 private:
     using Base = StructTable<std::string, std::string>;
-    bool first = true;
+    bool first = true;  ///< Whether this is the first load (skip activation)
 };
 
 #endif

--- a/src/data/SkillTable.hpp
+++ b/src/data/SkillTable.hpp
@@ -25,11 +25,41 @@
 #include "data/StructTable.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for skill definitions and localized names
+ *
+ * Loads skill data from the database "skills" table, providing access to
+ * skill IDs and their localized names. Skills represent character abilities
+ * such as crafting, combat, and magic skills.
+ *
+ * Database columns: skl_skill_id, skl_name, skl_name_english, skl_name_german
+ */
 class SkillTable : public StructTable<TYPE_OF_SKILL_ID, SkillStruct> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "skills"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the skills table
+     * @return Vector containing skill table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract skill ID from database row
+     * @param row Database result row
+     * @return Skill ID from skl_skill_id column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_SKILL_ID override;
+
+    /**
+     * @brief Parse database row into SkillStruct
+     * @param row Database result row
+     * @return Populated SkillStruct with server name and localized names
+     */
     auto assignTable(const Database::ResultTuple &row) -> SkillStruct override;
 };
 

--- a/src/data/SpellTable.hpp
+++ b/src/data/SpellTable.hpp
@@ -26,14 +26,31 @@
 
 #include <boost/functional/hash/hash.hpp>
 
+/**
+ * @brief Unique identifier for a spell
+ *
+ * Spells are identified by a composite key of magic type and spell ID,
+ * allowing different magic systems to have overlapping spell IDs.
+ */
 struct Spell {
-    uint8_t magicType;
-    uint32_t spellId;
+    uint8_t magicType;   ///< Type of magic (e.g., druid, priest, mage)
+    uint32_t spellId;    ///< Spell identifier within the magic type
 
+    /**
+     * @brief Equality comparison for spell lookup
+     * @param spell Spell to compare with
+     * @return true if both magic type and spell ID match
+     */
     auto operator==(const Spell &spell) const -> bool {
         return (magicType == spell.magicType && spellId == spell.spellId);
     }
 
+    /**
+     * @brief Stream output operator for debugging
+     * @param out Output stream
+     * @param spell Spell to output
+     * @return Reference to output stream
+     */
     friend auto operator<<(std::ostream &out, const Spell &spell) -> std::ostream & {
         out << "magic: " << spell.magicType << ", spell: " << spell.spellId;
         return out;
@@ -41,6 +58,12 @@ struct Spell {
 };
 
 namespace std {
+/**
+ * @brief Hash function specialization for Spell
+ *
+ * Enables use of Spell as a key in unordered_map by combining
+ * hashes of magic type and spell ID.
+ */
 template <> struct hash<Spell> {
     auto operator()(const Spell &s) const -> size_t {
         std::size_t seed = 0;
@@ -51,14 +74,61 @@ template <> struct hash<Spell> {
 };
 } // namespace std
 
+/**
+ * @brief Empty struct for spell data (all data is in scripts)
+ *
+ * Currently, spell properties are entirely handled by Lua scripts,
+ * so no additional data structure is needed.
+ */
 struct SpellStruct {};
 
+/**
+ * @brief Table for spell definitions and magic scripts
+ *
+ * Loads spell data from the database "spells" table, mapping spell identifiers
+ * to their associated Lua magic scripts. Each spell is uniquely identified by
+ * a combination of magic type and spell ID.
+ *
+ * All spell behavior (casting requirements, effects, mana cost, etc.) is
+ * implemented in the Lua scripts rather than in database columns.
+ *
+ * Database table: spells
+ * Columns: spl_magictype, spl_spellid, spl_scriptname
+ * Script type: LuaMagicScript
+ */
 class SpellTable : public ScriptStructTable<Spell, SpellStruct, LuaMagicScript> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "spells"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the spells table
+     * @return Vector containing spell table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract spell identifier from database row
+     * @param row Database result row
+     * @return Spell struct with magic type and spell ID
+     */
     auto assignId(const Database::ResultTuple &row) -> Spell override;
+
+    /**
+     * @brief Parse database row into SpellStruct
+     * @param row Database result row
+     * @return Empty SpellStruct (no data stored)
+     */
     auto assignTable(const Database::ResultTuple &row) -> SpellStruct override;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename from spl_scriptname column
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
 };
 

--- a/src/data/StructTable.hpp
+++ b/src/data/StructTable.hpp
@@ -31,10 +31,40 @@
 #include <unordered_map>
 #include <vector>
 
+/**
+ * @brief Template base class for tables storing structured data indexed by ID
+ *
+ * Provides a generic implementation of the Table interface for tables that
+ * store structured data (StructType) indexed by an ID (IdType). Data is
+ * loaded from database tables and stored in an unordered_map for fast lookup.
+ *
+ * This class implements double-buffering for safe runtime reloading:
+ * - Data is loaded into structBuffer via reloadBuffer()
+ * - Active data remains in structs during loading
+ * - activateBuffer() atomically swaps the two containers
+ *
+ * Derived classes must implement:
+ * - getTableName(): Return database table name
+ * - getColumnNames(): Return list of columns to query
+ * - assignId(): Extract ID from a database row
+ * - assignTable(): Parse database row into StructType
+ *
+ * @tparam IdType Type of the unique identifier (e.g., TYPE_OF_ITEM_ID, TYPE_OF_SKILL_ID)
+ * @tparam StructType Type of the data structure stored (e.g., CommonStruct, SkillStruct)
+ */
 template <typename IdType, typename StructType> class StructTable : public Table {
     using ContainerType = std::unordered_map<IdType, StructType>;
 
 public:
+    /**
+     * @brief Load table data from database into buffer
+     *
+     * Queries the database table and loads all rows into the buffer container.
+     * Uses the derived class implementations of getTableName(), getColumnNames(),
+     * assignId(), and assignTable() to construct the query and parse results.
+     *
+     * @return true if loading succeeded, false if an exception occurred
+     */
     auto reloadBuffer() -> bool override {
         try {
             Database::SelectQuery query;
@@ -62,16 +92,42 @@ public:
         return isBufferValid;
     }
 
+    /**
+     * @brief Reload associated scripts (no-op for basic StructTable)
+     *
+     * Override in derived classes that have script bindings to reload.
+     */
     void reloadScripts() override {}
 
+    /**
+     * @brief Swap buffer data into active storage
+     *
+     * Atomically swaps the buffered data container with the active one,
+     * then clears the buffer for the next reload cycle.
+     */
     void activateBuffer() override {
         structs.swap(structBuffer);
         isBufferValid = false;
         clear();
     }
 
+    /**
+     * @brief Check if an entry with the given ID exists
+     * @param id The ID to check
+     * @return true if entry exists, false otherwise
+     */
     auto exists(const IdType &id) const -> bool { return structs.count(id) > 0; }
 
+    /**
+     * @brief Access entry by ID with bounds checking
+     *
+     * Returns the entry for the given ID. If the ID doesn't exist, logs an
+     * error and creates a default entry.
+     *
+     * @param id The ID to look up
+     * @return Reference to the entry
+     * @note Creates a default entry if ID not found
+     */
     auto operator[](const IdType &id) -> const StructType & {
         try {
             return structs.at(id);
@@ -82,32 +138,95 @@ public:
         }
     }
 
+    /**
+     * @brief Get entry by ID (const version)
+     * @param id The ID to look up
+     * @return Const reference to the entry
+     * @throws std::out_of_range if ID not found
+     */
     auto get(const IdType &id) const -> const StructType & { return structs.at(id); }
 
+    /**
+     * @brief Get iterator to beginning of table
+     * @return Const iterator to first entry
+     */
     auto begin() const -> typename ContainerType::const_iterator { return structs.cbegin(); }
 
+    /**
+     * @brief Get iterator to end of table
+     * @return Const iterator to one past last entry
+     */
     auto end() const -> typename ContainerType::const_iterator { return structs.cend(); }
 
 protected:
+    /**
+     * @brief Get database table name
+     * @return Name of the database table to query
+     */
     [[nodiscard]] virtual auto getTableName() const -> std::string = 0;
+
+    /**
+     * @brief Get list of column names to query
+     * @return Vector of column names for the SELECT query
+     */
     virtual auto getColumnNames() -> std::vector<std::string> = 0;
+
+    /**
+     * @brief Extract ID from a database result row
+     * @param row Database result row
+     * @return The ID extracted from the row
+     */
     virtual auto assignId(const Database::ResultTuple &row) -> IdType = 0;
+
+    /**
+     * @brief Parse database row into struct
+     * @param row Database result row
+     * @return Populated StructType instance
+     */
     virtual auto assignTable(const Database::ResultTuple &row) -> StructType = 0;
 
+    /**
+     * @brief Clear the buffer container
+     *
+     * Override if custom cleanup is needed before loading new data.
+     */
     virtual void clear() { structBuffer.clear(); }
 
+    /**
+     * @brief Process a single database result row
+     *
+     * Extracts the ID and struct from the row and stores in buffer.
+     * Override for custom row processing logic.
+     *
+     * @param row Database result row to process
+     */
     virtual void evaluateRow(const Database::ResultTuple &row) { emplace(assignId(row), assignTable(row)); }
 
+    /**
+     * @brief Insert entry into buffer
+     * @param id Entry ID
+     * @param data Entry data
+     */
     virtual void emplace(const IdType &id, const StructType &data) { structBuffer.emplace(id, data); }
 
+    /**
+     * @brief Remove entry from active table
+     * @param id ID to remove
+     * @return true if entry was removed, false if not found
+     */
     auto erase(const IdType &id) -> bool { return structs.erase(id) > 0; }
 
+    /**
+     * @brief Get mutable reference to entry
+     * @param id Entry ID
+     * @return Mutable reference to entry (creates default if not found)
+     */
     auto get(const IdType &id) -> StructType & { return structs[id]; }
 
 private:
-    ContainerType structs;
-    ContainerType structBuffer;
-    bool isBufferValid = false;
+    ContainerType structs;      ///< Active data container
+    ContainerType structBuffer; ///< Buffer for reloading data
+    bool isBufferValid = false; ///< Whether buffer contains valid data
 };
 
 #endif

--- a/src/data/Table.hpp
+++ b/src/data/Table.hpp
@@ -21,11 +21,47 @@
 #ifndef TABLE_HPP
 #define TABLE_HPP
 
+/**
+ * @brief Abstract base class for all game data tables
+ *
+ * This interface defines the contract for table classes that load and manage
+ * game data from the database. Tables support double-buffering to allow safe
+ * reloading of data without interrupting gameplay.
+ *
+ * The typical reload workflow is:
+ * 1. Call reloadBuffer() to load new data into a buffer
+ * 2. Call reloadScripts() to refresh any associated script bindings
+ * 3. Call activateBuffer() to atomically swap the buffer with active data
+ */
 class Table {
 public:
+    /**
+     * @brief Reload table data from database into a buffer
+     *
+     * Loads fresh data from the database into an internal buffer without
+     * affecting the currently active data. This allows validation and
+     * preparation before activation.
+     *
+     * @return true if reload was successful, false on error
+     */
     virtual auto reloadBuffer() -> bool = 0;
+
+    /**
+     * @brief Reload script bindings associated with this table
+     *
+     * Refreshes any Lua script connections or callbacks that depend on
+     * this table's data. Called after reloadBuffer() but before activateBuffer().
+     */
     virtual void reloadScripts() = 0;
+
+    /**
+     * @brief Activate the buffered data, making it live
+     *
+     * Atomically swaps the buffered data with the active data. After this
+     * call, the newly loaded data becomes active and the old data is discarded.
+     */
     virtual void activateBuffer() = 0;
+
     Table() = default;
     virtual ~Table() = default;
     Table(const Table &) = default;

--- a/src/data/TilesModificatorTable.hpp
+++ b/src/data/TilesModificatorTable.hpp
@@ -25,12 +25,64 @@
 #include "data/StructTable.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for item-based tile modifications
+ *
+ * Loads tile modificator data from the database "tilesmodificators" table,
+ * defining how items placed on tiles modify their properties:
+ * - Blocking movement (walls, fences, large objects)
+ * - Special item flags (for quest/script purposes)
+ * - Making impassable tiles passable (bridges over water)
+ *
+ * When items are placed in the world, their tile modificator properties
+ * affect the tile's behavior. For example, a wall item makes the tile
+ * impassable, while a bridge item makes water tiles passable.
+ *
+ * @note TODO: The handling of tile modificators is extremely unsafe.
+ *       Errors in the database will corrupt data easily and uncontrollably.
+ *
+ * Database table: tilesmodificators
+ * Columns: tim_itemid, tim_isnotpassable, tim_specialitem, tim_makepassable
+ */
 class TilesModificatorTable : public StructTable<TYPE_OF_ITEM_ID, TilesModificatorStruct> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "tilesmodificators"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the tilesmodificators table
+     * @return Vector containing tile modificator column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract item ID from database row
+     * @param row Database result row
+     * @return Item ID from tim_itemid column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_ITEM_ID override;
+
+    /**
+     * @brief Parse database row into TilesModificatorStruct
+     * @param row Database result row
+     * @return Populated TilesModificatorStruct with modificator flags
+     */
     auto assignTable(const Database::ResultTuple &row) -> TilesModificatorStruct override;
+
+    /**
+     * @brief Check if an item allows passage
+     *
+     * Determines if a tile with this item placed on it can be walked through.
+     * An item is passable if it doesn't block the path OR if it explicitly
+     * makes the tile passable (like a bridge).
+     *
+     * @param id Item ID to check
+     * @return true if passable, false if blocks movement
+     * @note Returns true if item ID not found in table
+     */
     auto passable(TYPE_OF_ITEM_ID id) -> bool;
 };
 

--- a/src/data/TilesTable.hpp
+++ b/src/data/TilesTable.hpp
@@ -26,12 +26,57 @@
 #include "script/LuaTileScript.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for tile type definitions and properties
+ *
+ * Loads tile data from the database "tiles" table, defining the properties of
+ * different ground tile types in the game world:
+ * - Passability (whether characters can walk on the tile)
+ * - Walking cost (movement penalty/bonus)
+ * - Localized names (German and English)
+ * - Optional tile scripts for special behavior
+ *
+ * Tile types define the base terrain (grass, stone, water, etc.) and their
+ * traversal properties. Scripts can add special effects when characters
+ * walk on specific tile types.
+ *
+ * Database table: tiles
+ * Columns: til_id, til_isnotpassable, til_german, til_english, til_walkingcost, til_script
+ * Script type: LuaTileScript
+ */
 class TilesTable : public ScriptStructTable<TYPE_OF_TILE_ID, TilesStruct, LuaTileScript> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "tiles"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the tiles table
+     * @return Vector containing tile table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract tile ID from database row
+     * @param row Database result row
+     * @return Tile ID from til_id column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_TILE_ID override;
+
+    /**
+     * @brief Parse database row into TilesStruct
+     * @param row Database result row
+     * @return Populated TilesStruct with passability, names, and walking cost
+     */
     auto assignTable(const Database::ResultTuple &row) -> TilesStruct override;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename from til_script column, or empty string
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
 };
 

--- a/src/data/TriggerTable.hpp
+++ b/src/data/TriggerTable.hpp
@@ -24,19 +24,79 @@
 #include "globals.hpp"
 #include "script/LuaTriggerScript.hpp"
 
+/**
+ * @brief Data structure for trigger field properties
+ *
+ * Stores the position and associated script for a trigger field. Trigger
+ * fields are world tiles that execute scripts when characters enter them.
+ */
 struct TriggerStruct {
-    position pos{};
-    std::string scriptname;
-    std::shared_ptr<LuaTriggerScript> script;
+    position pos{};                                ///< World position of trigger
+    std::string scriptname;                        ///< Name of trigger script file
+    std::shared_ptr<LuaTriggerScript> script;      ///< Loaded script instance
 };
 
+/**
+ * @brief Table for trigger field definitions and scripts
+ *
+ * Loads trigger field data from the database "triggerfields" table, mapping
+ * world positions to trigger scripts. Trigger fields are invisible tiles that
+ * execute Lua scripts when characters step on them, enabling:
+ * - Area transitions (teleports, zone changes)
+ * - Environmental effects (damage, buffs)
+ * - Quest progression triggers
+ * - Trap activation
+ *
+ * Uses position as the unique identifier since each tile can only have one
+ * trigger. Supports both main trigger scripts and quest-specific trigger
+ * scripts via QuestScriptStructTable.
+ *
+ * @note ScriptParameter is position (not TriggerStruct), so scripts are
+ *       constructed with position only
+ *
+ * Database table: triggerfields
+ * Columns: tgf_posx, tgf_posy, tgf_posz, tgf_script
+ * Script type: LuaTriggerScript
+ */
 class TriggerTable : public QuestScriptStructTable<position, TriggerStruct, LuaTriggerScript, position> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "triggerfields"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the triggerfields table
+     * @return Vector containing trigger table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract position from database row
+     * @param row Database result row
+     * @return Position struct from tgf_posx/y/z columns
+     */
     auto assignId(const Database::ResultTuple &row) -> position override;
+
+    /**
+     * @brief Parse database row into TriggerStruct
+     * @param row Database result row
+     * @return TriggerStruct with position populated
+     */
     auto assignTable(const Database::ResultTuple &row) -> TriggerStruct override;
+
+    /**
+     * @brief Extract script filename from database row
+     * @param row Database result row
+     * @return Script filename from tgf_script column
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
+
+    /**
+     * @brief Get quest script nodes for triggers
+     * @return Iterator range over trigger quest nodes
+     */
     auto getQuestScripts() -> NodeRange override;
 };
 

--- a/src/data/WeaponObjectTable.hpp
+++ b/src/data/WeaponObjectTable.hpp
@@ -26,12 +26,56 @@
 #include "script/LuaWeaponScript.hpp"
 #include "types.hpp"
 
+/**
+ * @brief Table for weapon combat properties and scripts
+ *
+ * Loads weapon data from the database "weapon" table, providing access to
+ * combat statistics for items that function as weapons:
+ * - Combat stats (attack, defence, accuracy, range)
+ * - Weapon classification (type, ammunition type)
+ * - Combat mechanics (action points, magic disturbance)
+ * - Special effects (poison strength)
+ * - Optional fighting scripts for custom weapon behavior
+ *
+ * Weapon properties are looked up by item ID, allowing items to function
+ * as weapons when they have an entry in this table.
+ *
+ * Database table: weapon
+ * Script type: LuaWeaponScript
+ */
 class WeaponObjectTable : public ScriptStructTable<TYPE_OF_ITEM_ID, WeaponStruct, LuaWeaponScript> {
 public:
+    /**
+     * @brief Get database table name
+     * @return "weapon"
+     */
     auto getTableName() const -> std::string override;
+
+    /**
+     * @brief Get column names for the weapon table
+     * @return Vector containing weapon table column names
+     */
     auto getColumnNames() -> std::vector<std::string> override;
+
+    /**
+     * @brief Extract item ID from database row
+     * @param row Database result row
+     * @return Item ID from wp_itemid column
+     */
     auto assignId(const Database::ResultTuple &row) -> TYPE_OF_ITEM_ID override;
+
+    /**
+     * @brief Parse database row into WeaponStruct
+     * @param row Database result row
+     * @return Populated WeaponStruct with combat properties
+     */
     auto assignTable(const Database::ResultTuple &row) -> WeaponStruct override;
+
+    /**
+     * @brief Extract fighting script filename from database row
+     * @param row Database result row
+     * @return Script filename from wp_fightingscript column, or empty string
+     */
     auto assignScriptName(const Database::ResultTuple &row) -> std::string override;
 };
 

--- a/src/db/Connection.hpp
+++ b/src/db/Connection.hpp
@@ -30,32 +30,106 @@
 namespace Database {
 class Connection;
 
+/**
+ * @brief Shared pointer type for database connections.
+ */
 using PConnection = std::shared_ptr<Connection>;
 
+/**
+ * @brief Manages a PostgreSQL database connection and transaction lifecycle.
+ * 
+ * Connection wraps the libpqxx library to provide a simplified interface for
+ * database operations. It handles:
+ * - Connection establishment to PostgreSQL
+ * - Transaction management (begin, commit, rollback)
+ * - Query execution within transactions
+ * - Bulk data streaming for efficient inserts
+ * - SQL string escaping and quoting
+ * 
+ * All queries must be executed within an active transaction. The connection
+ * automatically rolls back any uncommitted transactions.
+ * 
+ * @note This class is movable but not copyable
+ * @see ConnectionManager for connection pooling
+ */
 class Connection {
 private:
-    /* The libpqxx representation of the connection to the database. */
-    std::unique_ptr<pqxx::connection> internalConnection = nullptr;
-    std::unique_ptr<pqxx::transaction_base> transaction = nullptr;
+    std::unique_ptr<pqxx::connection> internalConnection = nullptr; ///< PostgreSQL connection handle
+    std::unique_ptr<pqxx::transaction_base> transaction = nullptr; ///< Active transaction (nullptr if none)
 
 public:
+    /**
+     * @brief Creates a database connection using a PostgreSQL connection string.
+     * 
+     * @param connectionString libpqxx connection string (e.g., "host=localhost dbname=illarion")
+     * @throws pqxx::broken_connection if connection fails
+     */
     explicit Connection(const std::string &connectionString);
+    
     Connection(const Connection &) = delete;
     Connection(Connection &&) = default;
     auto operator=(const Connection &) -> Connection & = delete;
     auto operator=(Connection &&) -> Connection & = default;
     ~Connection() = default;
 
+    /**
+     * @brief Starts a new transaction, rolling back any existing transaction.
+     * 
+     * @throws std::domain_error if internal connection is not established
+     */
     void beginTransaction();
+    
+    /**
+     * @brief Executes a SQL query within the active transaction.
+     * 
+     * @param query SQL query string
+     * @return Query result set
+     * @throws std::domain_error if no transaction is active
+     */
     auto query(const std::string &query) -> pqxx::result;
+    
+    /**
+     * @brief Creates a stream for bulk data insertion.
+     * 
+     * Provides efficient bulk loading using PostgreSQL COPY protocol.
+     * 
+     * @param path Target table path
+     * @param columns Column names for the insertion
+     * @return pqxx::stream_to object for streaming data
+     * @throws std::domain_error if no transaction is active
+     */
     auto streamTo(pqxx::table_path path, std::initializer_list<std::string_view> columns) -> pqxx::stream_to;
+    
+    /**
+     * @brief Commits the active transaction.
+     * 
+     * If no transaction is active, does nothing. Resets transaction to nullptr after commit.
+     */
     void commitTransaction();
+    
+    /**
+     * @brief Rolls back the active transaction.
+     * 
+     * If no transaction is active, does nothing. Resets transaction to nullptr after rollback.
+     */
     void rollbackTransaction();
 
+    /**
+     * @brief Quotes and escapes a value for safe SQL inclusion.
+     * 
+     * @tparam T Type of value to quote (string, int, etc.)
+     * @param t Value to quote
+     * @return Properly escaped SQL string literal
+     */
     template <typename T> [[nodiscard]] inline auto quote(const T &t) const -> std::string {
         return internalConnection->quote(t);
     }
 
+    /**
+     * @brief Checks if a transaction is currently active.
+     * 
+     * @return true if transaction is active, false otherwise
+     */
     [[nodiscard]] inline auto transactionActive() const -> bool { return bool(transaction); }
 };
 

--- a/src/db/DeleteQuery.hpp
+++ b/src/db/DeleteQuery.hpp
@@ -27,16 +27,56 @@
 #include "db/Result.hpp"
 
 namespace Database {
+/**
+ * @brief Builder class for constructing and executing SQL DELETE queries.
+ * 
+ * DeleteQuery provides a type-safe builder for DELETE statements with support for:
+ * - Single table deletion (via QueryTables mixin)
+ * - WHERE conditions (via QueryWhere mixin)
+ * 
+ * The class enforces single-table deletes only for safety.
+ * 
+ * Example usage:
+ * @code
+ * DeleteQuery query;
+ * query.addServerTable("old_items");
+ * query.addWhereClause("created_at", "<", "2020-01-01");
+ * query.execute(); // DELETE FROM old_items WHERE created_at < '2020-01-01';
+ * @endcode
+ * 
+ * @warning Always use WHERE clauses to avoid accidentally deleting all rows
+ * @note DeleteQuery is non-copyable and non-movable
+ * @see Query
+ * @see QueryTables
+ * @see QueryWhere
+ */
 class DeleteQuery : Query, public QueryTables, public QueryWhere {
 public:
+    /**
+     * @brief Creates a DELETE query with auto-acquired connection.
+     */
     DeleteQuery();
+    
+    /**
+     * @brief Creates a DELETE query with specified connection.
+     * 
+     * @param connection Database connection to use
+     */
     explicit DeleteQuery(const PConnection &connection);
+    
     DeleteQuery(const DeleteQuery &org) = delete;
     auto operator=(const DeleteQuery &org) -> DeleteQuery & = delete;
     DeleteQuery(DeleteQuery &&) = delete;
     auto operator=(DeleteQuery &&) -> DeleteQuery & = delete;
     ~DeleteQuery() override = default;
 
+    /**
+     * @brief Builds and executes the DELETE query.
+     * 
+     * Constructs the SQL from table and WHERE clauses.
+     * 
+     * @return Query result (typically shows number of rows deleted)
+     */
     auto execute() -> Result override;
 };
 

--- a/src/db/InsertQuery.hpp
+++ b/src/db/InsertQuery.hpp
@@ -35,27 +35,95 @@
 #include <vector>
 
 namespace Database {
+/**
+ * @brief Builder class for constructing and executing SQL INSERT queries.
+ * 
+ * InsertQuery provides a type-safe builder for INSERT statements with support for:
+ * - Multiple rows in a single INSERT
+ * - Column specification (via QueryColumns mixin)
+ * - Table specification (via QueryTables mixin)
+ * - Type-safe value insertion
+ * - Batch value insertion from vectors and maps
+ * 
+ * The class uses a column-based approach where values are added by column index,
+ * and rows are automatically created as needed.
+ * 
+ * Example usage:
+ * @code
+ * InsertQuery query;
+ * query.addColumn("name").addColumn("level");
+ * query.addServerTable("chars");
+ * query.addValue(0, "Alice");
+ * query.addValue(1, 5);
+ * query.addValue(0, "Bob");
+ * query.addValue(1, 10);
+ * query.execute(); // INSERT INTO chars (name, level) VALUES ('Alice', 5), ('Bob', 10);
+ * @endcode
+ * 
+ * @note InsertQuery is movable but not copyable
+ * @see Query
+ * @see QueryColumns
+ * @see QueryTables
+ */
 class InsertQuery : Query, public QueryColumns, public QueryTables {
 private:
-    std::vector<std::vector<std::optional<std::string>>> dataStorage;
+    std::vector<std::vector<std::optional<std::string>>> dataStorage; ///< Row-major storage of quoted values
 
 public:
-    enum MapInsertMode { onlyKeys, onlyValues, keysAndValues };
+    /**
+     * @brief Mode for inserting map data into columns.
+     */
+    enum MapInsertMode { 
+        onlyKeys,      ///< Insert only map keys
+        onlyValues,    ///< Insert only map values
+        keysAndValues  ///< Insert keys in one column, values in next
+    };
 
-    static const uint32_t FILL = UINT32_C(0xFFFFFFFF);
+    static const uint32_t FILL = UINT32_C(0xFFFFFFFF); ///< Special count value to fill all existing rows
 
+    /**
+     * @brief Creates an INSERT query with auto-acquired connection.
+     */
     InsertQuery();
+    
+    /**
+     * @brief Creates an INSERT query with specified connection.
+     * 
+     * @param connection Database connection to use
+     */
     explicit InsertQuery(const PConnection &connection);
+    
     InsertQuery(const InsertQuery &org) = delete;
     auto operator=(const InsertQuery &org) -> InsertQuery & = delete;
     InsertQuery(InsertQuery &&) = default;
     auto operator=(InsertQuery &&) -> InsertQuery & = default;
     ~InsertQuery() override = default;
 
+    /**
+     * @brief Adds a single value to a column.
+     * 
+     * Creates a new row with this value if all existing rows have values for this column.
+     * 
+     * @tparam T Type of value
+     * @param column Column index (0-based)
+     * @param value Value to insert
+     * @throws std::invalid_argument if column index out of range
+     */
     template <typename T> void addValue(const QueryColumns::columnIndex &column, const T &value) {
         addValues(column, value, 1);
     }
 
+    /**
+     * @brief Adds the same value to a column for multiple rows.
+     * 
+     * First fills existing empty cells in this column, then creates new rows as needed.
+     * 
+     * @tparam T Type of value
+     * @param column Column index (0-based)
+     * @param value Value to insert
+     * @param count Number of rows to insert (FILL to fill all existing rows only)
+     * @throws std::invalid_argument if column index out of range
+     */
     template <typename T> void addValues(const QueryColumns::columnIndex &column, const T &value, uint32_t count) {
         if (count == 0) {
             return;
@@ -96,12 +164,28 @@ public:
         }
     }
 
+    /**
+     * @brief Adds values from a vector, one per row.
+     * 
+     * @tparam T Type of values
+     * @param column Column index
+     * @param values Vector of values to insert
+     */
     template <typename T> void addValues(const QueryColumns::columnIndex &column, const std::vector<T> &values) {
         for (const auto &value : values) {
             addValue<T>(column, value);
         }
     }
 
+    /**
+     * @brief Adds values from a map (keys, values, or both).
+     * 
+     * @tparam Key Map key type
+     * @tparam T Map value type
+     * @param column Starting column index
+     * @param values Map to insert from
+     * @param mode How to insert map data (keys, values, or both)
+     */
     template <typename Key, typename T>
     void addValues(const QueryColumns::columnIndex &column, const std::map<Key, T> &values,
                    MapInsertMode mode = keysAndValues) {
@@ -135,6 +219,11 @@ public:
         }
     }
 
+    /**
+     * @brief Builds and executes the INSERT query.
+     * 
+     * @return Query result (typically empty for INSERT)
+     */
     auto execute() -> Result override;
 };
 } // namespace Database

--- a/src/db/Query.hpp
+++ b/src/db/Query.hpp
@@ -27,34 +27,131 @@
 #include <string>
 
 namespace Database {
+/**
+ * @brief Base class for constructing and executing SQL queries.
+ * 
+ * Query provides a foundation for building SQL statements with automatic
+ * connection management and transaction handling. Key features:
+ * - Automatic connection acquisition from ConnectionManager
+ * - Automatic transaction management (creates/commits if needed)
+ * - SQL identifier escaping for table/column names
+ * - Value quoting for safe SQL generation
+ * - String list building utilities
+ * 
+ * Subclasses like SelectQuery, InsertQuery, UpdateQuery, and DeleteQuery
+ * provide type-safe builders for specific SQL operations.
+ * 
+ * @note Query is movable but not copyable
+ * @see SelectQuery
+ * @see InsertQuery
+ * @see UpdateQuery
+ * @see DeleteQuery
+ */
 class Query {
 private:
-    PConnection dbConnection;
-    std::string dbQuery;
+    PConnection dbConnection; ///< Shared database connection
+    std::string dbQuery; ///< SQL query string
 
 public:
+    /**
+     * @brief Creates a query with auto-acquired connection.
+     * 
+     * @param query SQL query string to execute
+     */
     explicit Query(const std::string &query);
+    
+    /**
+     * @brief Creates a query with specified connection.
+     * 
+     * @param connection Database connection to use
+     * @param query SQL query string to execute
+     */
     Query(PConnection connection, std::string query);
+    
     Query(const Query &) = delete;
     Query(Query &&) = default;
     auto operator=(const Query &) -> Query & = delete;
     auto operator=(Query &&) -> Query & = default;
     virtual ~Query() = default;
 
+    /**
+     * @brief Escapes a SQL identifier (table/column name) with double quotes.
+     * 
+     * If already quoted, returns as-is. Otherwise wraps in double quotes.
+     * 
+     * @param key Identifier to escape
+     * @return Quoted identifier string
+     */
     static auto escapeKey(const std::string &key) -> std::string;
+    
+    /**
+     * @brief Chains two identifiers with a dot (for schema.table or table.column).
+     * 
+     * Both identifiers are escaped before chaining.
+     * 
+     * @param key1 First identifier (schema or table)
+     * @param key2 Second identifier (table or column)
+     * @return Escaped and chained identifier string
+     */
     static auto escapeAndChainKeys(const std::string &key1, const std::string &key2) -> std::string;
+    
+    /**
+     * @brief Appends an entry to a comma-separated list.
+     * 
+     * Adds ", " separator if list is non-empty.
+     * 
+     * @param list String list to append to
+     * @param newEntry Entry to add
+     */
     static void appendToStringList(std::string &list, const std::string &newEntry);
+    
+    /**
+     * @brief Quotes a value for safe SQL inclusion.
+     * 
+     * @tparam T Type of value to quote
+     * @param value Value to quote
+     * @return Properly escaped SQL literal
+     */
     template <typename T> [[nodiscard]] auto quote(T value) const -> std::string {
         return dbConnection->quote<T>(value);
     }
 
+    /**
+     * @brief Executes the query and returns the result.
+     * 
+     * Automatically manages transaction lifecycle: begins transaction if none active,
+     * executes query, and commits if it created the transaction.
+     * 
+     * @return Query result set
+     * @throws std::domain_error if connection or query string is missing
+     */
     virtual auto execute() -> Result;
 
 protected:
+    /**
+     * @brief Protected constructor for subclasses with auto-acquired connection.
+     */
     Query();
+    
+    /**
+     * @brief Protected constructor for subclasses with specified connection.
+     * 
+     * @param connection Database connection to use
+     */
     explicit Query(PConnection /*connection*/);
 
+    /**
+     * @brief Sets the SQL query string.
+     * 
+     * @param query SQL query string
+     */
     void setQuery(const std::string &query);
+    
+    /**
+     * @brief Gets the database connection.
+     * 
+     * @return Shared pointer to connection
+     */
     auto getConnection() -> PConnection;
 };
 } // namespace Database

--- a/src/db/Result.hpp
+++ b/src/db/Result.hpp
@@ -25,12 +25,37 @@
 #include <pqxx/result_iterator.hxx>
 
 namespace Database {
-/* This file contains just some namespaces that hide the pqxx implementation
- * of the SQL Query result handling.
+/**
+ * @brief Type aliases for PostgreSQL query result handling.
+ * 
+ * These aliases wrap the pqxx library result types, providing a simplified
+ * interface and hiding the implementation details. Result types include:
+ * - Result: Complete result set from a query
+ * - ResultTuple: Single row from a result set
+ * - ResultField: Single field/column value from a row
+ * - PResult: Pointer to a result set
+ * 
+ * @see pqxx::result for underlying implementation
+ */
+
+/**
+ * @brief Query result set type.
  */
 using Result = pqxx::result;
+
+/**
+ * @brief Single row from a result set.
+ */
 using ResultTuple = pqxx::row;
+
+/**
+ * @brief Single field/column value from a row.
+ */
 using ResultField = pqxx::field;
+
+/**
+ * @brief Pointer to a result set.
+ */
 using PResult = Result *;
 } // namespace Database
 

--- a/src/db/SelectQuery.hpp
+++ b/src/db/SelectQuery.hpp
@@ -32,27 +32,95 @@
 #include <string>
 
 namespace Database {
+/**
+ * @brief Builder class for constructing and executing SQL SELECT queries.
+ * 
+ * SelectQuery provides a type-safe builder pattern for SELECT statements with support for:
+ * - Column selection (via QueryColumns mixin)
+ * - Table joins (via QueryTables mixin)
+ * - WHERE conditions (via QueryWhere mixin)
+ * - ORDER BY clauses with direction
+ * - DISTINCT keyword
+ * 
+ * Example usage:
+ * @code
+ * SelectQuery query;
+ * query.addColumn("name").addColumn("level");
+ * query.addServerTable("chars");
+ * query.addWhereClause("char_id", "=", 123);
+ * query.addOrderBy("name", SelectQuery::ASC);
+ * auto result = query.execute();
+ * @endcode
+ * 
+ * @note SelectQuery is non-copyable and non-movable
+ * @see Query
+ * @see QueryColumns
+ * @see QueryTables
+ * @see QueryWhere
+ */
 class SelectQuery : Query, public QueryColumns, public QueryTables, public QueryWhere {
 private:
-    std::string orderBy;
-    bool isDistinct{false};
+    std::string orderBy; ///< ORDER BY clause string
+    bool isDistinct{false}; ///< Whether to use DISTINCT keyword
 
 public:
-    enum OrderDirection { ASC, DESC };
+    /**
+     * @brief Sort direction for ORDER BY clauses.
+     */
+    enum OrderDirection { 
+        ASC,  ///< Ascending order
+        DESC  ///< Descending order
+    };
 
+    /**
+     * @brief Creates a SELECT query with auto-acquired connection.
+     */
     SelectQuery();
+    
+    /**
+     * @brief Creates a SELECT query with specified connection.
+     * 
+     * @param connection Database connection to use
+     */
     explicit SelectQuery(const PConnection &connection);
+    
     SelectQuery(const SelectQuery &org) = delete;
     auto operator=(const SelectQuery &org) -> SelectQuery & = delete;
     SelectQuery(SelectQuery &&) = delete;
     auto operator=(SelectQuery &&) -> SelectQuery & = delete;
     ~SelectQuery() override = default;
 
+    /**
+     * @brief Adds an ORDER BY clause for a column.
+     * 
+     * @param column Column name to sort by
+     * @param dir Sort direction (ASC or DESC)
+     */
     void addOrderBy(const std::string &column, const OrderDirection &dir);
+    
+    /**
+     * @brief Adds an ORDER BY clause for a table-qualified column.
+     * 
+     * @param table Table name
+     * @param column Column name to sort by
+     * @param dir Sort direction (ASC or DESC)
+     */
     void addOrderBy(const std::string &table, const std::string &column, const OrderDirection &dir);
 
+    /**
+     * @brief Enables or disables DISTINCT keyword in SELECT.
+     * 
+     * @param distinct true to use SELECT DISTINCT, false for SELECT
+     */
     void setDistinct(const bool &distinct);
 
+    /**
+     * @brief Builds and executes the SELECT query.
+     * 
+     * Constructs the SQL from all configured clauses and executes it.
+     * 
+     * @return Query result set
+     */
     auto execute() -> Result override;
 };
 } // namespace Database

--- a/src/db/UpdateQuery.hpp
+++ b/src/db/UpdateQuery.hpp
@@ -32,16 +32,59 @@
 #include <string>
 
 namespace Database {
+/**
+ * @brief Builder class for constructing and executing SQL UPDATE queries.
+ * 
+ * UpdateQuery provides a type-safe builder for UPDATE statements with support for:
+ * - Column value assignment (via QueryAssign mixin)
+ * - Single table updates (via QueryTables mixin)
+ * - WHERE conditions (via QueryWhere mixin)
+ * 
+ * The class enforces single-table updates only for safety.
+ * 
+ * Example usage:
+ * @code
+ * UpdateQuery query;
+ * query.addServerTable("chars");
+ * query.addAssignColumn("level", 10);
+ * query.addAssignColumn("experience", 5000);
+ * query.addWhereClause("char_id", "=", 123);
+ * query.execute(); // UPDATE chars SET level = 10, experience = 5000 WHERE char_id = 123;
+ * @endcode
+ * 
+ * @note UpdateQuery is non-copyable and non-movable
+ * @see Query
+ * @see QueryAssign
+ * @see QueryTables
+ * @see QueryWhere
+ */
 class UpdateQuery : Query, public QueryAssign, public QueryTables, public QueryWhere {
 public:
+    /**
+     * @brief Creates an UPDATE query with auto-acquired connection.
+     */
     UpdateQuery();
+    
+    /**
+     * @brief Creates an UPDATE query with specified connection.
+     * 
+     * @param connection Database connection to use
+     */
     explicit UpdateQuery(const PConnection &connection);
+    
     UpdateQuery(const UpdateQuery &org) = delete;
     auto operator=(const UpdateQuery &org) -> UpdateQuery & = delete;
     UpdateQuery(UpdateQuery &&) = delete;
     auto operator=(UpdateQuery &&) -> UpdateQuery & = delete;
     ~UpdateQuery() override = default;
 
+    /**
+     * @brief Builds and executes the UPDATE query.
+     * 
+     * Constructs the SQL from table, SET assignments, and WHERE clauses.
+     * 
+     * @return Query result (typically shows number of rows affected)
+     */
     auto execute() -> Result override;
 };
 } // namespace Database

--- a/src/dialog/CraftingDialog.hpp
+++ b/src/dialog/CraftingDialog.hpp
@@ -30,18 +30,52 @@
 
 using std::vector;
 
+/**
+ * @brief Ingredient requirement for crafting
+ *
+ * Specifies an item type and quantity required as input for a crafting recipe.
+ */
 class Ingredient {
 private:
-    TYPE_OF_ITEM_ID item;
-    uint8_t number;
+    TYPE_OF_ITEM_ID item;   ///< Item ID required
+    uint8_t number;         ///< Quantity needed
 
 public:
+    /**
+     * @brief Construct ingredient with single item
+     * @param item Item ID required
+     */
     explicit Ingredient(TYPE_OF_ITEM_ID item) : item(item), number(1){};
+
+    /**
+     * @brief Construct ingredient with specific quantity
+     * @param item Item ID required
+     * @param number Quantity needed
+     */
     Ingredient(TYPE_OF_ITEM_ID item, uint8_t number) : item(item), number(number){};
+
+    /**
+     * @brief Get item ID
+     * @return Required item ID
+     */
     [[nodiscard]] auto getItem() const -> TYPE_OF_ITEM_ID { return item; };
+
+    /**
+     * @brief Get required quantity
+     * @return Number of items needed
+     */
     [[nodiscard]] auto getNumber() const -> uint8_t { return number; };
 };
 
+/**
+ * @brief Craftable item recipe definition
+ *
+ * Defines a complete crafting recipe including:
+ * - Output item and quantity
+ * - Required ingredients and quantities
+ * - Crafting time
+ * - Display name and category group
+ */
 class Craftable {
 public:
     using index_t = uint8_t;
@@ -50,40 +84,91 @@ public:
 
 private:
     static const uint32_t MAXINGREDIENTS = 256;
-    uint8_t group;
-    TYPE_OF_ITEM_ID item;
-    string name;
-    ingredients_t ingredients;
-    uint16_t decisecondsToCraft;
-    uint8_t craftedStackSize;
+    uint8_t group;                  ///< Category/group ID for organization
+    TYPE_OF_ITEM_ID item;           ///< Item produced by this recipe
+    string name;                    ///< Display name of the recipe
+    ingredients_t ingredients;      ///< Required ingredients
+    uint16_t decisecondsToCraft;    ///< Crafting time in deciseconds (1/10 sec)
+    uint8_t craftedStackSize;       ///< Number of items produced
 
 public:
+    /**
+     * @brief Construct craftable with single output item
+     * @param group Category group
+     * @param item Item ID produced
+     * @param name Display name
+     * @param decisecondsToCraft Crafting time in deciseconds
+     */
     Craftable(uint8_t group, TYPE_OF_ITEM_ID item, string name, uint16_t decisecondsToCraft)
             : group(group), item(item), name(std::move(name)), decisecondsToCraft(decisecondsToCraft),
               craftedStackSize(1){};
+
+    /**
+     * @brief Construct craftable with stack output
+     * @param group Category group
+     * @param item Item ID produced
+     * @param name Display name
+     * @param decisecondsToCraft Crafting time in deciseconds
+     * @param craftedStackSize Number of items produced
+     */
     Craftable(uint8_t group, TYPE_OF_ITEM_ID item, string name, uint16_t decisecondsToCraft, uint8_t craftedStackSize)
             : group(group), item(item), name(std::move(name)), decisecondsToCraft(decisecondsToCraft),
               craftedStackSize(craftedStackSize){};
+
     [[nodiscard]] auto getGroup() const -> uint8_t { return group; };
     [[nodiscard]] auto getItem() const -> TYPE_OF_ITEM_ID { return item; };
     [[nodiscard]] auto getName() const -> const string & { return name; };
     [[nodiscard]] auto getDecisecondsToCraft() const -> uint16_t { return decisecondsToCraft; };
     [[nodiscard]] auto getCraftedStackSize() const -> uint8_t { return craftedStackSize; };
+
+    /**
+     * @brief Add single ingredient requirement
+     * @param item Item ID required
+     */
     void addIngredient(TYPE_OF_ITEM_ID item) {
         if (ingredients.size() < MAXINGREDIENTS) {
             ingredients.emplace_back(item);
         }
     };
+
+    /**
+     * @brief Add ingredient with specific quantity
+     * @param item Item ID required
+     * @param number Quantity needed
+     */
     void addIngredient(TYPE_OF_ITEM_ID item, uint8_t number) {
         if (ingredients.size() < MAXINGREDIENTS) {
             ingredients.emplace_back(item, number);
         }
     };
+
     [[nodiscard]] auto getIngredientsSize() const -> index_t { return ingredients.size(); };
     [[nodiscard]] auto begin() const -> ingredient_iterator { return ingredients.cbegin(); };
     [[nodiscard]] auto end() const -> ingredient_iterator { return ingredients.cend(); };
 };
 
+/**
+ * @brief Interactive crafting dialog
+ *
+ * Presents a crafting interface to players showing:
+ * - Recipe categories/groups
+ * - Available recipes with ingredient requirements
+ * - Crafting progress and completion
+ * - Item inspection for outputs and ingredients
+ *
+ * Supports:
+ * - Multiple recipe categories for organization
+ * - Variable crafting times
+ * - Stack crafting (multiple outputs)
+ * - Sound effects during crafting
+ * - Callbacks for result handling
+ *
+ * Results indicate player actions:
+ * - Selecting and starting a craft
+ * - Inspecting items
+ * - Aborting crafting
+ * - Completing crafts
+ */
 class CraftingDialog : public Dialog {
 public:
     using index_t = uint8_t;
@@ -92,51 +177,102 @@ public:
     using craftables_t = std::map<uint8_t, Craftable>;
     using craftable_iterator = craftables_t::const_iterator;
 
+    /**
+     * @brief Player actions in crafting dialog
+     */
     enum Result {
-        playerAborts = 0,
-        playerCrafts = 1,
-        playerLooksAtCraftable = 2,
-        playerLooksAtIngredient = 3,
-        playerCraftingComplete = 4,
-        playerCraftingAborted = 5
+        playerAborts = 0,              ///< Player closed dialog
+        playerCrafts = 1,              ///< Player started crafting
+        playerLooksAtCraftable = 2,    ///< Player inspected output item
+        playerLooksAtIngredient = 3,   ///< Player inspected ingredient
+        playerCraftingComplete = 4,    ///< Crafting finished successfully
+        playerCraftingAborted = 5      ///< Crafting was interrupted
     };
 
 private:
-    static constexpr auto maximumCraftables = 256;
-    static constexpr auto maximumGroups = 256;
-    uint16_t sfx{};
-    uint16_t sfxDuration{};
-    groups_t groups;
-    craftables_t craftables;
+    static constexpr auto maximumCraftables = 256;  ///< Max recipes that can be shown
+    static constexpr auto maximumGroups = 256;      ///< Max category groups
+    uint16_t sfx{};                 ///< Sound effect ID during crafting
+    uint16_t sfxDuration{};         ///< Duration of sound effect
+    groups_t groups;                ///< Recipe category names
+    craftables_t craftables;        ///< Available recipes
 
-    Result result{playerAborts};
+    Result result{playerAborts};    ///< Last player action
 
-    uint8_t craftableId{0};
-    Item::number_type craftableAmount{0};
-    index_t ingredientIndex{0};
+    uint8_t craftableId{0};                 ///< Selected recipe ID
+    Item::number_type craftableAmount{0};   ///< Quantity to craft
+    index_t ingredientIndex{0};             ///< Inspected ingredient index
 
-    uint8_t lastAddedCraftableId{0};
+    uint8_t lastAddedCraftableId{0};        ///< Last added recipe (for ingredient assignment)
 
 public:
+    /**
+     * @brief Construct crafting dialog
+     * @param title Dialog title
+     * @param sfx Sound effect ID for crafting
+     * @param sfxDuration Sound effect duration in deciseconds
+     * @param callback Lua callback function
+     */
     CraftingDialog(const string &title, uint16_t sfx, uint16_t sfxDuration, const luabind::object &callback);
 
     [[nodiscard]] auto getSfx() const -> uint16_t;
     [[nodiscard]] auto getSfxDuration() const -> uint16_t;
 
+    /**
+     * @brief Clear all groups and recipes
+     *
+     * Removes all categories and craftable items, allowing the dialog
+     * to be repopulated with new recipes.
+     */
     void clearGroupsAndProducts();
 
     [[nodiscard]] auto getGroupsSize() const -> index_t;
     [[nodiscard]] auto getGroupsBegin() const -> group_iterator;
     [[nodiscard]] auto getGroupsEnd() const -> group_iterator;
+
+    /**
+     * @brief Add a recipe category
+     * @param name Category name to display
+     */
     void addGroup(const string &name);
 
     [[nodiscard]] auto getCraftablesSize() const -> index_t;
     [[nodiscard]] auto getCraftablesBegin() const -> craftable_iterator;
     [[nodiscard]] auto getCraftablesEnd() const -> craftable_iterator;
+
+    /**
+     * @brief Add a craftable recipe
+     * @param id Recipe ID
+     * @param group Category group ID
+     * @param item Output item ID
+     * @param name Recipe display name
+     * @param decisecondsToCraft Crafting time in 1/10 seconds
+     */
     void addCraftable(uint8_t id, uint8_t group, TYPE_OF_ITEM_ID item, const string &name, uint16_t decisecondsToCraft);
+
+    /**
+     * @brief Add craftable recipe with stack output
+     * @param id Recipe ID
+     * @param group Category group ID
+     * @param item Output item ID
+     * @param name Recipe display name
+     * @param decisecondsToCraft Crafting time in 1/10 seconds
+     * @param craftedStackSize Number of items produced
+     */
     void addCraftable(uint8_t id, uint8_t group, TYPE_OF_ITEM_ID item, const string &name, uint16_t decisecondsToCraft,
                       uint8_t craftedStackSize);
+
+    /**
+     * @brief Add ingredient to last added craftable
+     * @param item Ingredient item ID
+     */
     void addCraftableIngredient(TYPE_OF_ITEM_ID item);
+
+    /**
+     * @brief Add ingredient with quantity to last added craftable
+     * @param item Ingredient item ID
+     * @param number Quantity required
+     */
     void addCraftableIngredient(TYPE_OF_ITEM_ID item, uint8_t number);
 
     [[nodiscard]] auto getResult() const -> Result;
@@ -150,9 +286,18 @@ public:
     void setIngredientIndex(index_t index);
     [[nodiscard]] auto getCraftableTime() const -> uint16_t;
 
+    /**
+     * @brief Check if dialog closes when player moves
+     * @return true - crafting dialog closes on movement
+     */
     [[nodiscard]] auto closeOnMove() const -> bool override;
 
 private:
+    /**
+     * @brief Validate group ID exists
+     * @param group Group ID to check
+     * @return true if group is valid
+     */
     [[nodiscard]] auto canAddCraftable(uint8_t group) const -> bool;
 };
 

--- a/src/dialog/Dialog.hpp
+++ b/src/dialog/Dialog.hpp
@@ -26,22 +26,57 @@
 
 using std::string;
 
+/**
+ * @brief Base class for all player-facing dialog windows.
+ *
+ * This abstract class provides the foundation for interactive dialogs shown to players,
+ * including a title, class identifier for client rendering, and a Lua callback function
+ * that handles player responses.
+ */
 class Dialog {
 private:
-    string title;
-    string className;
-    luabind::object callback;
+    string title;             ///< The dialog window title shown to the player.
+    string className;         ///< CSS-like class name for client-side styling.
+    luabind::object callback; ///< Lua function called when player responds to the dialog.
 
 public:
+    /**
+     * @brief Constructs a dialog with title, class, and callback.
+     * @param title The dialog window title.
+     * @param className The CSS-like class for client rendering.
+     * @param callback Lua function to invoke when player responds.
+     */
     Dialog(string title, string className, const luabind::object &callback);
+
     Dialog(const Dialog &dialog) = default;
     auto operator=(const Dialog &) -> Dialog & = default;
     Dialog(Dialog &&) = default;
     auto operator=(Dialog &&) -> Dialog & = default;
     virtual ~Dialog() = default;
+
+    /**
+     * @brief Gets the dialog window title.
+     * @return The title string.
+     */
     [[nodiscard]] auto getTitle() const -> const string &;
+
+    /**
+     * @brief Gets the CSS-like class name for client rendering.
+     * @return The class name string.
+     */
     [[nodiscard]] auto getClassName() const -> const string &;
+
+    /**
+     * @brief Gets the Lua callback function.
+     * @return The callback object.
+     */
     [[nodiscard]] auto getCallback() const -> const luabind::object &;
+
+    /**
+     * @brief Determines if this dialog should close when the player moves.
+     * @return true if dialog auto-closes on movement, false to keep it open.
+     * @note Default implementation returns true; override for persistent dialogs.
+     */
     [[nodiscard]] virtual auto closeOnMove() const -> bool;
 };
 

--- a/src/dialog/InputDialog.hpp
+++ b/src/dialog/InputDialog.hpp
@@ -23,23 +23,73 @@
 
 #include "dialog/Dialog.hpp"
 
+/**
+ * @brief A dialog that prompts the player to enter text input.
+ *
+ * This dialog collects text input from the player, supporting both single-line
+ * and multi-line text entry with configurable character limits. The success flag
+ * indicates whether the player confirmed or cancelled the input.
+ */
 class InputDialog : public Dialog {
 private:
-    string description;
-    bool multiline{};
-    short maxChars{};
-    bool success{false};
-    string input;
+    string description;  ///< Descriptive text prompting the player for input.
+    bool multiline{};    ///< Whether to allow multi-line text entry.
+    short maxChars{};    ///< Maximum number of characters allowed (0 = unlimited).
+    bool success{false}; ///< True if player confirmed input, false if cancelled.
+    string input;        ///< The text entered by the player.
 
 public:
+    /**
+     * @brief Constructs an input dialog.
+     * @param title The dialog window title.
+     * @param description Prompt text explaining what input is needed.
+     * @param multiline Whether to show a multi-line text area.
+     * @param maxChars Maximum character limit (0 for no limit).
+     * @param callback Lua function called when player submits or cancels.
+     */
     InputDialog(const string &title, string description, bool multiline, short maxChars,
                 const luabind::object &callback);
+
+    /**
+     * @brief Gets the input prompt description.
+     * @return The description text.
+     */
     [[nodiscard]] auto getDescription() const -> const string &;
+
+    /**
+     * @brief Checks if multi-line input is enabled.
+     * @return true for multi-line text area, false for single-line input.
+     */
     [[nodiscard]] auto isMultiline() const -> bool;
+
+    /**
+     * @brief Gets the maximum character limit.
+     * @return The character limit, or 0 for unlimited.
+     */
     [[nodiscard]] auto getMaxChars() const -> short;
+
+    /**
+     * @brief Checks if the player confirmed the input.
+     * @return true if player clicked OK/Submit, false if cancelled.
+     */
     [[nodiscard]] auto getSuccess() const -> bool;
+
+    /**
+     * @brief Sets the success flag when player responds.
+     * @param success true for confirmation, false for cancellation.
+     */
     void setSuccess(bool success);
+
+    /**
+     * @brief Gets the text entered by the player.
+     * @return The input string (empty if cancelled).
+     */
     [[nodiscard]] auto getInput() const -> const string &;
+
+    /**
+     * @brief Sets the player's input text.
+     * @param input The text entered by the player.
+     */
     void setInput(string input);
 };
 

--- a/src/dialog/MerchantDialog.hpp
+++ b/src/dialog/MerchantDialog.hpp
@@ -29,97 +29,311 @@
 
 using std::vector;
 
+/**
+ * @brief Represents a product that can be bought or sold in a merchant dialog.
+ */
 class Product {
 private:
-    TYPE_OF_ITEM_ID item;
-    string name;
-    TYPE_OF_WORTH price;
+    TYPE_OF_ITEM_ID item; ///< Item ID for the product.
+    string name; ///< Display name of the product.
+    TYPE_OF_WORTH price; ///< Price of the product in currency.
 
 public:
+    /**
+     * @brief Constructs a product with item, name, and price.
+     * @param item Item ID.
+     * @param name Display name.
+     * @param price Price in currency.
+     */
     Product(TYPE_OF_ITEM_ID item, string name, TYPE_OF_WORTH price) : item(item), name(std::move(name)), price(price){};
+
+    /**
+     * @brief Gets the item ID.
+     * @return The item ID.
+     */
     [[nodiscard]] auto getItem() const -> TYPE_OF_ITEM_ID { return item; };
+
+    /**
+     * @brief Gets the product name.
+     * @return The display name.
+     */
     [[nodiscard]] auto getName() const -> const string & { return name; };
+
+    /**
+     * @brief Gets the product price.
+     * @return The price value.
+     */
     [[nodiscard]] auto getPrice() const -> TYPE_OF_WORTH { return price; };
 };
 
+/**
+ * @brief A product offered for sale by the merchant, with stack size information.
+ */
 class OfferProduct : public Product {
 private:
-    TYPE_OF_BUY_STACK stack;
+    TYPE_OF_BUY_STACK stack; ///< Default stack size when purchasing.
 
 public:
+    /**
+     * @brief Constructs an offered product with stack size.
+     * @param item Item ID.
+     * @param name Display name.
+     * @param price Price per stack.
+     * @param stack Number of items per purchase.
+     */
     OfferProduct(TYPE_OF_ITEM_ID item, const string &name, TYPE_OF_WORTH price, TYPE_OF_BUY_STACK stack)
             : Product(item, name, price), stack(stack){};
+
+    /**
+     * @brief Gets the stack size for this product.
+     * @return The number of items per purchase.
+     */
     [[nodiscard]] auto getStack() const -> TYPE_OF_BUY_STACK { return stack; };
 };
 
+/**
+ * @brief A merchant/trading dialog for buying and selling items.
+ *
+ * This dialog implements a merchant interface with three lists:
+ * - Offers: Items the merchant sells to the player
+ * - Primary Requests: Items the merchant primarily wants to buy
+ * - Secondary Requests: Items the merchant will also buy (usually at lower prices)
+ *
+ * The player can browse items, purchase from offers, sell items to the merchant,
+ * or examine items for details.
+ */
 class MerchantDialog : public Dialog {
 public:
-    using index_type = uint8_t;
-    using product_list = vector<Product>;
-    using product_iterator = product_list::const_iterator;
-    using offer_list = vector<OfferProduct>;
-    using offer_iterator = offer_list::const_iterator;
+    using index_type = uint8_t; ///< Type for product indices.
+    using product_list = vector<Product>; ///< Container for products.
+    using product_iterator = product_list::const_iterator; ///< Iterator for products.
+    using offer_list = vector<OfferProduct>; ///< Container for offered products.
+    using offer_iterator = offer_list::const_iterator; ///< Iterator for offers.
 
-    enum Result { playerAborts = 0, playerSells = 1, playerBuys = 2, playerLooksAt = 3 };
+    /**
+     * @brief Player's action result from the merchant dialog.
+     */
+    enum Result { 
+        playerAborts = 0,   ///< Player closed dialog without action.
+        playerSells = 1,    ///< Player sold an item to merchant.
+        playerBuys = 2,     ///< Player purchased an item from merchant.
+        playerLooksAt = 3   ///< Player examined an item's details.
+    };
 
-    enum ListType { listSell = 0, listBuyPrimary = 1, listBuySecondary = 2 };
+    /**
+     * @brief Which product list the player is interacting with.
+     */
+    enum ListType { 
+        listSell = 0,           ///< Merchant's offers (items for sale).
+        listBuyPrimary = 1,     ///< Primary items merchant wants to buy.
+        listBuySecondary = 2    ///< Secondary items merchant will buy.
+    };
 
 private:
-    static const uint32_t MAXPRODUCTS = 256;
-    offer_list offers;
-    product_list primaryRequests;
-    product_list secondaryRequests;
+    static const uint32_t MAXPRODUCTS = 256; ///< Maximum products per list.
+    offer_list offers; ///< Items the merchant offers for sale.
+    product_list primaryRequests; ///< Items the merchant primarily wants to buy.
+    product_list secondaryRequests; ///< Items the merchant will also buy.
 
-    Result result{playerAborts};
+    Result result{playerAborts}; ///< The player's action result.
 
-    index_type purchaseIndex{0};
-    Item::number_type purchaseAmount{0};
+    index_type purchaseIndex{0}; ///< Index of item being purchased.
+    Item::number_type purchaseAmount{0}; ///< Quantity of item being purchased.
 
-    ScriptItem saleItem;
+    ScriptItem saleItem; ///< Item the player is selling to the merchant.
 
-    ListType lookAtList{listSell};
+    ListType lookAtList{listSell}; ///< Which list the examined item is in.
 
 public:
+    /**
+     * @brief Constructs a merchant dialog.
+     * @param title The dialog window title (usually merchant's name).
+     * @param callback Lua function called when transaction completes.
+     */
     MerchantDialog(const string &title, const luabind::object &callback);
 
+    /**
+     * @brief Gets the number of items offered for sale.
+     * @return The offer count.
+     */
     auto getOffersSize() const -> index_type;
+
+    /**
+     * @brief Gets iterator to first offered item.
+     * @return Begin iterator for offers.
+     */
     auto getOffersBegin() const -> offer_iterator;
+
+    /**
+     * @brief Gets iterator past last offered item.
+     * @return End iterator for offers.
+     */
     auto getOffersEnd() const -> offer_iterator;
+
+    /**
+     * @brief Adds an item to the merchant's sale offerings.
+     * @param item Item ID to offer.
+     * @param name Display name of the item.
+     * @param price Price per item.
+     */
     void addOffer(TYPE_OF_ITEM_ID item, const string &name, TYPE_OF_WORTH price);
+
+    /**
+     * @brief Adds an item with stack size to merchant's offerings.
+     * @param item Item ID to offer.
+     * @param name Display name of the item.
+     * @param price Price per stack.
+     * @param stack Number of items per purchase.
+     */
     void addOffer(TYPE_OF_ITEM_ID item, const string &name, TYPE_OF_WORTH price, TYPE_OF_BUY_STACK stack);
 
+    /**
+     * @brief Gets the number of primary buy requests.
+     * @return The primary request count.
+     */
     auto getPrimaryRequestsSize() const -> index_type;
+
+    /**
+     * @brief Gets iterator to first primary request.
+     * @return Begin iterator.
+     */
     auto getPrimaryRequestsBegin() const -> product_iterator;
+
+    /**
+     * @brief Gets iterator past last primary request.
+     * @return End iterator.
+     */
     auto getPrimaryRequestsEnd() const -> product_iterator;
+
+    /**
+     * @brief Adds an item to primary buy requests.
+     * @param item Item ID the merchant wants.
+     * @param name Display name.
+     * @param price Price merchant will pay.
+     */
     void addPrimaryRequest(TYPE_OF_ITEM_ID item, const string &name, TYPE_OF_WORTH price);
 
+    /**
+     * @brief Gets the number of secondary buy requests.
+     * @return The secondary request count.
+     */
     auto getSecondaryRequestsSize() const -> index_type;
+
+    /**
+     * @brief Gets iterator to first secondary request.
+     * @return Begin iterator.
+     */
     auto getSecondaryRequestsBegin() const -> product_iterator;
+
+    /**
+     * @brief Gets iterator past last secondary request.
+     * @return End iterator.
+     */
     auto getSecondaryRequestsEnd() const -> product_iterator;
+
+    /**
+     * @brief Adds an item to secondary buy requests.
+     * @param item Item ID the merchant will buy.
+     * @param name Display name.
+     * @param price Price merchant will pay.
+     */
     void addSecondaryRequest(TYPE_OF_ITEM_ID item, const string &name, TYPE_OF_WORTH price);
 
+    /**
+     * @brief Gets the player's action result.
+     * @return The result enum value.
+     */
     auto getResult() const -> Result;
+
+    /**
+     * @brief Sets the player's action result.
+     * @param result The result value.
+     */
     void setResult(Result result);
 
+    /**
+     * @brief Gets the index of item being purchased/examined.
+     * @return The item index.
+     */
     auto getPurchaseIndex() const -> index_type;
+
+    /**
+     * @brief Sets the index of item being purchased/examined.
+     * @param index The item index.
+     */
     void setPurchaseIndex(index_type index);
+
+    /**
+     * @brief Gets the quantity being purchased.
+     * @return The purchase amount.
+     */
     auto getPurchaseAmount() const -> Item::number_type;
+
+    /**
+     * @brief Sets the quantity being purchased.
+     * @param amount The purchase amount.
+     */
     void setPurchaseAmount(Item::number_type amount);
 
+    /**
+     * @brief Gets the item the player is selling.
+     * @return The sale item.
+     */
     auto getSaleItem() const -> const ScriptItem &;
+
+    /**
+     * @brief Sets the item the player is selling.
+     * @param item The item being sold.
+     */
     void setSaleItem(const ScriptItem &item);
 
+    /**
+     * @brief Gets which list the examined item is in.
+     * @return The list type.
+     */
     auto getLookAtList() const -> ListType;
+
+    /**
+     * @brief Sets which list the examined item is in.
+     * @param list The list type.
+     */
     void setLookAtList(ListType list);
 
+    /**
+     * @brief Checks if this dialog closes on player movement.
+     * @return Always false - merchant dialogs stay open.
+     */
     auto closeOnMove() const -> bool override;
 
 private:
+    /**
+     * @brief Helper to get product list size.
+     */
     static auto getProductsSize(const product_list &products) -> index_type;
+
+    /**
+     * @brief Helper to get product list begin iterator.
+     */
     static auto getProductsBegin(const product_list &products) -> product_iterator;
+
+    /**
+     * @brief Helper to get product list end iterator.
+     */
     static auto getProductsEnd(const product_list &products) -> product_iterator;
+
+    /**
+     * @brief Helper to add product to a list.
+     */
     static void addProduct(product_list &products, TYPE_OF_ITEM_ID item, const string &name, TYPE_OF_WORTH price);
+
+    /**
+     * @brief Checks if another offer can be added.
+     */
     auto canAddOffer() const -> bool;
+
+    /**
+     * @brief Checks if another product can be added to a list.
+     */
     static auto canAddProduct(const product_list &products) -> bool;
 };
 

--- a/src/dialog/MessageDialog.hpp
+++ b/src/dialog/MessageDialog.hpp
@@ -21,14 +21,29 @@
 #ifndef MESSAGE_DIALOG_HPP
 #define MESSAGE_DIALOG_HPP
 
-#include "dialog/Dialog.hpp"
-
+/**
+ * @brief A simple message dialog that displays text to the player.
+ *
+ * This dialog shows informational text with an "OK" button (or equivalent).
+ * Commonly used for notifications, hints, or simple confirmations.
+ */
 class MessageDialog : public Dialog {
 private:
-    string text;
+    string text; ///< The message text to display to the player.
 
 public:
+    /**
+     * @brief Constructs a message dialog.
+     * @param title The dialog window title.
+     * @param text The message text to display.
+     * @param callback Lua function called when player closes the dialog.
+     */
     MessageDialog(const string &title, string text, const luabind::object &callback);
+
+    /**
+     * @brief Gets the message text.
+     * @return The message text string.
+     */
     [[nodiscard]] auto getText() const -> const string &;
 };
 

--- a/src/dialog/SelectionDialog.hpp
+++ b/src/dialog/SelectionDialog.hpp
@@ -29,52 +29,135 @@
 
 using std::vector;
 
+/**
+ * @brief Represents a selectable option in a selection dialog.
+ *
+ * Each option has an associated item ID (for icon display) and a text name.
+ */
 class Option {
 private:
-    TYPE_OF_ITEM_ID item;
-    string name;
+    TYPE_OF_ITEM_ID item; ///< Item ID for displaying an icon next to the option.
+    string name; ///< Display text for this option.
 
 public:
+    /**
+     * @brief Constructs an option with item and name.
+     * @param item Item ID for the option icon.
+     * @param name Display text for the option.
+     */
     Option(TYPE_OF_ITEM_ID item, string name) : item(item), name(std::move(name)){};
+
+    /**
+     * @brief Gets the item ID for icon display.
+     * @return The item ID.
+     */
     [[nodiscard]] auto getItem() const -> TYPE_OF_ITEM_ID { return item; };
+
+    /**
+     * @brief Gets the display name of this option.
+     * @return The option name.
+     */
     [[nodiscard]] auto getName() const -> const string & { return name; };
 };
 
+/**
+ * @brief A dialog that presents a list of options for the player to choose from.
+ *
+ * This dialog shows descriptive text and a list of selectable options, each with
+ * an optional item icon. The player selects one option and confirms or cancels.
+ * Commonly used for menus, choices in quests, or selecting from a list of items.
+ */
 class SelectionDialog : public Dialog {
 public:
-    using index_type = uint8_t;
-    using options_type = vector<Option>;
-    using iterator_type = options_type::const_iterator;
+    using index_type = uint8_t; ///< Type for option indices.
+    using options_type = vector<Option>; ///< Container type for options.
+    using iterator_type = options_type::const_iterator; ///< Iterator type for options.
 
 private:
-    string text;
+    string text; ///< Descriptive text explaining the selection.
 
-    static const uint32_t MAXOPTIONS = 256;
-    options_type options;
+    static const uint32_t MAXOPTIONS = 256; ///< Maximum number of options allowed.
+    options_type options; ///< List of available options.
 
-    bool success{false};
+    bool success{false}; ///< True if player confirmed a selection, false if cancelled.
 
-    index_type selectedIndex{0};
+    index_type selectedIndex{0}; ///< Index of the option selected by the player.
 
-    bool close{false};
+    bool close{false}; ///< Whether this dialog should close on player movement.
 
 public:
+    /**
+     * @brief Constructs a selection dialog.
+     * @param title The dialog window title.
+     * @param text Descriptive text explaining the selection.
+     * @param callback Lua function called when player makes a selection or cancels.
+     */
     SelectionDialog(const string &title, string text, const luabind::object &callback);
 
+    /**
+     * @brief Gets the descriptive text.
+     * @return The description text.
+     */
     [[nodiscard]] auto getText() const -> const string &;
 
+    /**
+     * @brief Gets the number of available options.
+     * @return The option count.
+     */
     [[nodiscard]] auto getOptionsSize() const -> index_type;
+
+    /**
+     * @brief Gets an iterator to the first option.
+     * @return Begin iterator for options.
+     */
     [[nodiscard]] auto begin() const -> iterator_type;
+
+    /**
+     * @brief Gets an iterator past the last option.
+     * @return End iterator for options.
+     */
     [[nodiscard]] auto end() const -> iterator_type;
+
+    /**
+     * @brief Adds an option to the selection list.
+     * @param item Item ID for the option icon.
+     * @param name Display text for the option.
+     */
     void addOption(TYPE_OF_ITEM_ID item, const string &name);
 
+    /**
+     * @brief Checks if the player confirmed a selection.
+     * @return true if player selected and confirmed, false if cancelled.
+     */
     [[nodiscard]] auto getSuccess() const -> bool;
+
+    /**
+     * @brief Sets the success flag when player responds.
+     * @param success true for confirmation, false for cancellation.
+     */
     void setSuccess(bool success);
 
+    /**
+     * @brief Gets the index of the selected option.
+     * @return The selected option index (0-based).
+     */
     [[nodiscard]] auto getSelectedIndex() const -> index_type;
+
+    /**
+     * @brief Sets the selected option index.
+     * @param index The option index selected by the player.
+     */
     void setSelectedIndex(index_type index);
 
+    /**
+     * @brief Marks this dialog to close when the player moves.
+     */
     void setCloseOnMove();
+
+    /**
+     * @brief Checks if this dialog closes on player movement.
+     * @return true if dialog should close on movement.
+     */
     [[nodiscard]] auto closeOnMove() const -> bool override;
 };
 

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -28,9 +28,22 @@
 #include <iostream>
 #include <map>
 
+/**
+ * @brief Exception thrown when a requested field does not exist on the map.
+ */
 struct FieldNotFound : std::exception {};
+
+/**
+ * @brief Exception thrown when a map operation encounters an error.
+ */
 struct MapError : std::exception {};
 
+/**
+ * @brief Represents a 3D coordinate in the game world.
+ * 
+ * Contains x, y coordinates on the map plane and z for elevation/level.
+ * Provides movement and comparison operations for spatial calculations.
+ */
 struct position {
     Coordinate x;
     Coordinate y;
@@ -101,6 +114,11 @@ struct position {
     }
 };
 
+/**
+ * @brief Comparator for position objects to enable use in sorted containers.
+ * 
+ * Orders positions lexicographically by x, then y, then z coordinates.
+ */
 struct PositionComparison {
     auto operator()(const position &pos1, const position &pos2) const -> bool {
         if (pos1.x == pos2.x) {
@@ -113,12 +131,27 @@ struct PositionComparison {
     }
 };
 
+/**
+ * @brief Standard library namespace.
+ */
 namespace std {
+
+/**
+ * @brief Hash specialization for position to enable use in unordered containers.
+ * 
+ * Allows position objects to be keys in std::unordered_map and std::unordered_set.
+ */
 template <> struct hash<position> {
     auto operator()(const position &p) const -> size_t { return hash_value(p); }
 };
 } // namespace std
 
+/**
+ * @brief Represents a 2D coordinate on the map plane.
+ * 
+ * Similar to position but without elevation (z coordinate). Used for map-level
+ * operations that don't require height information.
+ */
 struct MapPosition {
     Coordinate x;
     Coordinate y;
@@ -139,11 +172,22 @@ struct MapPosition {
 };
 
 namespace std {
+
+/**
+ * @brief Hash specialization for MapPosition to enable use in unordered containers.
+ * 
+ * Allows MapPosition objects to be keys in std::unordered_map and std::unordered_set.
+ */
 template <> struct hash<MapPosition> {
     auto operator()(const MapPosition &p) const -> size_t { return hash_value(p); }
 };
 } // namespace std
 
+/**
+ * @brief Defines a spatial range with horizontal and vertical radii.
+ * 
+ * Used for area-of-effect calculations, visibility checks, and range queries.
+ */
 struct Range {
     Coordinate radius = 0;
     Coordinate zRadius = RANGEUP;

--- a/src/map/Field.hpp
+++ b/src/map/Field.hpp
@@ -28,27 +28,67 @@
 
 namespace map {
 
+/**
+ * @brief Represents a single tile on the game world map.
+ *
+ * A Field contains all data for one map coordinate including:
+ * - Tile graphics (primary, secondary, and overlay layers)
+ * - Background music ID
+ * - Items stacked on the ground
+ * - Containers placed on the field
+ * - Occupancy flags (player, NPC, monster)
+ * - Warp destination (for teleport tiles)
+ * - Persistence flag for database synchronization
+ *
+ * Field manages:
+ * - Item stacking (up to MAXITEMS)
+ * - Walkability calculation based on tiles and items
+ * - Character occupation tracking for pathfinding
+ * - Database persistence for dynamic changes
+ * - Container hierarchy for nested storage
+ *
+ * Tile encoding uses bit-packing:
+ * - Bits 0-4: Primary tile ID (5 bits)
+ * - Bits 5-9: Secondary tile ID (5 bits)
+ * - Bits 10-15: Overlay tile ID (6 bits)
+ *
+ * @note Thread safety: Fields should only be accessed through Map locks
+ * @see Map for field access and iteration
+ * @see Item for items placed on fields
+ */
 class Field {
 private:
-    static constexpr uint16_t TRANSPARENT = 0;
-    static constexpr uint16_t tileIdBits = 10;
-    static constexpr uint16_t primaryTileIdBits = 5;
-    static constexpr uint16_t overlayTileBitMask = 0b1111'1100'0000'0000;
-    static constexpr uint16_t secondaryTileBitMask = 0b0000'0011'1110'0000;
-    static constexpr uint16_t primaryTileBitMask = 0b0000'0000'0001'1111;
+    static constexpr uint16_t TRANSPARENT = 0; ///< Tile ID for transparent/empty tiles
+    static constexpr uint16_t tileIdBits = 10; ///< Bit shift for overlay tile extraction
+    static constexpr uint16_t primaryTileIdBits = 5; ///< Bit shift for secondary tile extraction
+    static constexpr uint16_t overlayTileBitMask = 0b1111'1100'0000'0000; ///< Mask for overlay tile (bits 10-15)
+    static constexpr uint16_t secondaryTileBitMask = 0b0000'0011'1110'0000; ///< Mask for secondary tile (bits 5-9)
+    static constexpr uint16_t primaryTileBitMask = 0b0000'0000'0001'1111; ///< Mask for primary tile (bits 0-4)
 
-    uint16_t tile = 0;
-    uint16_t music = 0;
-    uint8_t flags = 0;
-    position here;
-    position warptarget{};
-    std::vector<Item> items;
-    bool persistent = false;
+    uint16_t tile = 0; ///< Packed tile code (primary + secondary + overlay)
+    uint16_t music = 0; ///< Background music ID for this field
+    uint8_t flags = 0; ///< Occupancy and property flags (walkability, characters, special items)
+    position here; ///< 3D coordinates of this field
+    position warptarget{}; ///< Destination coordinates if this is a warp field
+    std::vector<Item> items; ///< Items stacked on ground (bottom to top)
+    bool persistent = false; ///< If true, changes are saved to database
 
 public:
-    Container::CONTAINERMAP containers;
+    Container::CONTAINERMAP containers; ///< Containers placed on this field (indexed by item stack position)
 
+    /**
+     * @brief Constructs field with just position (for temporary fields).
+     * @param here Position in world coordinates
+     */
     explicit Field(const position &here) : here(here){};
+
+    /**
+     * @brief Constructs field with full initialization.
+     * @param tile Packed tile code (or primary tile ID)
+     * @param music Background music ID
+     * @param here Position in world coordinates
+     * @param persistent If true, load from database and save changes
+     */
     Field(uint16_t tile, uint16_t music, const position &here, bool persistent = false);
     Field(const Field &) = delete;
     auto operator=(const Field &) -> Field & = delete;
@@ -56,80 +96,340 @@ public:
     auto operator=(Field &&) -> Field & = default;
     ~Field() = default;
 
+    /**
+     * @brief Sets primary tile ID and updates database/clients.
+     * @param id New tile ID from tiles table
+     */
     void setTileId(uint16_t id);
+
+    /**
+     * @brief Returns primary or overlay tile ID based on layering.
+     * @return Effective visible tile ID for rendering
+     */
     [[nodiscard]] auto getTileId() const -> uint16_t;
+
+    /**
+     * @brief Returns secondary or primary tile ID for multi-layer tiles.
+     * @return Secondary layer tile ID, or primary if no overlay
+     */
     [[nodiscard]] auto getSecondaryTileId() const -> uint16_t;
+
+    /**
+     * @brief Returns raw packed tile code.
+     * @return Full 16-bit tile encoding
+     */
     [[nodiscard]] auto getTileCode() const -> uint16_t;
+
+    /**
+     * @brief Checks if field is transparent (empty space).
+     * @return True if tile ID is 0 (no ground)
+     */
     [[nodiscard]] auto isTransparent() const -> bool;
 
+    /**
+     * @brief Sets background music ID and updates database/clients.
+     * @param id Music track ID from content tables
+     */
     void setMusicId(uint16_t id);
+
+    /**
+     * @brief Returns background music ID for this field.
+     * @return Music track ID
+     */
     [[nodiscard]] auto getMusicId() const -> uint16_t;
 
+    /**
+     * @brief Checks if characters can walk through this field.
+     * @return True if tile and items allow movement
+     *
+     * @note Considers tile properties, item blocking, and FLAG_MAKEPASSABLE
+     */
     [[nodiscard]] auto isWalkable() const -> bool;
+
+    /**
+     * @brief Checks if movement to this field is allowed (walkable + unoccupied).
+     * @return True if field is walkable and no character occupies it
+     */
     [[nodiscard]] auto moveToPossible() const -> bool;
+
+    /**
+     * @brief Calculates movement cost for pathfinding.
+     * @return Walking cost (lower = faster), or max value if unwalkable
+     *
+     * Uses minimum walking cost from primary and secondary tiles.
+     */
     [[nodiscard]] auto getMovementCost() const -> TYPE_OF_WALKINGCOST;
+
+    /**
+     * @brief Checks if field contains items with special scripted behavior.
+     * @return True if any item has FLAG_SPECIALITEM
+     */
     [[nodiscard]] auto hasSpecialItem() const -> bool;
 
+    /**
+     * @brief Adds item to top of stack.
+     * @param item Item to add
+     * @return True if added successfully, false if stack full (>= MAXITEMS)
+     */
     auto addItemOnStack(const Item &item) -> bool;
+
+    /**
+     * @brief Adds item only if field remains walkable after placement.
+     * @param item Item to add
+     * @return True if added and field still walkable
+     */
     auto addItemOnStackIfWalkable(const Item &item) -> bool;
+
+    /**
+     * @brief Removes and returns top item from stack.
+     * @param item Output parameter receiving the removed item
+     * @return True if item removed, false if stack empty
+     */
     auto takeItemFromStack(Item &item) -> bool;
+
+    /**
+     * @brief Increases quantity of top item on stack.
+     * @param count Number to add to item's number field
+     * @param erased Output: true if item was removed due to reaching 0 or overflow
+     * @return Actual count added before removal/overflow
+     */
     auto increaseItemOnStack(int count, bool &erased) -> int;
+
+    /**
+     * @brief Replaces top item with different item ID.
+     * @param newId New item ID from items table
+     * @param newQuality Optional quality override (0 = keep current)
+     * @return True if swapped, false if stack empty
+     */
     auto swapItemOnStack(TYPE_OF_ITEM_ID newId, uint16_t newQuality = 0) -> bool;
+
+    /**
+     * @brief Retrieves top item without removing it.
+     * @param item Output parameter receiving item copy
+     * @return True if item exists, false if stack empty
+     */
     auto viewItemOnStack(Item &item) const -> bool;
+
+    /**
+     * @brief Gets item at specific position in stack for scripts.
+     * @param pos Stack index (0 = bottom)
+     * @return ScriptItem wrapper with position metadata
+     */
     [[nodiscard]] auto getStackItem(uint8_t pos) const -> ScriptItem;
+
+    /**
+     * @brief Returns const reference to entire item stack.
+     * @return Vector of items from bottom to top
+     */
     [[nodiscard]] auto getItemStack() const -> const std::vector<Item> &;
+
+    /**
+     * @brief Returns number of items on field.
+     * @return Item count (0-MAXITEMS)
+     */
     [[nodiscard]] auto itemCount() const -> MAXCOUNTTYPE;
 
+    /**
+     * @brief Adds container item only if field remains walkable.
+     * @param item Container item to add
+     * @param container Pointer to Container object for nested storage
+     * @return True if added and field still walkable
+     */
     auto addContainerOnStackIfWalkable(Item item, Container *container) -> bool;
+
+    /**
+     * @brief Adds container item to field.
+     * @param item Container item to add
+     * @param container Pointer to Container object for nested storage
+     * @return True if added successfully
+     */
     auto addContainerOnStack(Item item, Container *container) -> bool;
+
+    /**
+     * @brief Retrieves container at specific stack position.
+     * @param count Stack index
+     * @return Pointer to Container, or nullptr if position invalid or not a container
+     */
     [[nodiscard]] auto GetContainer(MAXCOUNTTYPE count) const -> Container *;
 
+    /**
+     * @brief Ages items on field (for decay/spoilage systems).
+     *
+     * Called periodically to update item durability and trigger decay scripts.
+     */
     void age();
 
+    /**
+     * @brief Marks field as occupied by a player.
+     */
     void setPlayer();
+
+    /**
+     * @brief Marks field as occupied by an NPC.
+     */
     void setNPC();
+
+    /**
+     * @brief Marks field as occupied by a monster.
+     */
     void setMonster();
+
+    /**
+     * @brief Removes player occupation flag.
+     */
     void removePlayer();
+
+    /**
+     * @brief Removes NPC occupation flag.
+     */
     void removeNPC();
+
+    /**
+     * @brief Removes monster occupation flag.
+     */
     void removeMonster();
+
+    /**
+     * @brief Checks if a player occupies this field.
+     * @return True if FLAG_PLAYERONFIELD is set
+     */
     [[nodiscard]] auto hasPlayer() const -> bool;
+
+    /**
+     * @brief Checks if an NPC occupies this field.
+     * @return True if FLAG_NPCONFIELD is set
+     */
     [[nodiscard]] auto hasNPC() const -> bool;
+
+    /**
+     * @brief Checks if a monster occupies this field.
+     * @return True if FLAG_MONSTERONFIELD is set
+     */
     [[nodiscard]] auto hasMonster() const -> bool;
+
+    /**
+     * @brief Marks field as occupied by any character type.
+     */
     void setChar();
+
+    /**
+     * @brief Removes all character occupation flags.
+     */
     void removeChar();
 
+    /**
+     * @brief Sets this field as a warp/teleport tile.
+     * @param pos Destination coordinates for teleportation
+     */
     void setWarp(const position &pos);
+
+    /**
+     * @brief Removes warp destination from field.
+     */
     void removeWarp();
+
+    /**
+     * @brief Retrieves warp destination coordinates.
+     * @param pos Output parameter receiving warp target position
+     */
     void getWarp(position &pos) const;
+
+    /**
+     * @brief Checks if field is a warp/teleport tile.
+     * @return True if FLAG_WARPFIELD is set
+     */
     [[nodiscard]] auto isWarp() const -> bool;
 
+    /**
+     * @brief Returns items for world export/backup.
+     * @return Copy of items suitable for serialization
+     */
     [[nodiscard]] auto getExportItems() const -> std::vector<Item>;
+
+    /**
+     * @brief Saves field state to binary file streams.
+     * @param mapStream Map tile data output
+     * @param itemStream Item stack data output
+     * @param warpStream Warp destinations output
+     * @param containerStream Container hierarchy output
+     */
     void save(std::ofstream &mapStream, std::ofstream &itemStream, std::ofstream &warpStream,
               std::ofstream &containerStream) const;
+
+    /**
+     * @brief Loads field state from binary file streams.
+     * @param mapStream Map tile data input
+     * @param itemStream Item stack data input
+     * @param warpStream Warp destinations input
+     * @param containerStream Container hierarchy input
+     */
     void load(std::ifstream &mapStream, std::ifstream &itemStream, std::ifstream &warpStream,
               std::ifstream &containerStream);
 
+    /**
+     * @brief Returns field's world coordinates.
+     * @return Const reference to position
+     */
     [[nodiscard]] auto getPosition() const -> const position &;
 
+    /**
+     * @brief Enables database persistence for this field.
+     *
+     * Future changes will be saved to database automatically.
+     */
     void makePersistent();
+
+    /**
+     * @brief Disables database persistence and removes from database.
+     */
     void removePersistence();
+
+    /**
+     * @brief Checks if field changes are persisted to database.
+     * @return True if persistent flag set
+     */
     [[nodiscard]] auto isPersistent() const -> bool;
 
 private:
+    /**
+     * @brief Recalculates walkability and special flags from tiles and items.
+     */
     void updateFlags();
+
+    /**
+     * @brief Sets specific flag bits.
+     * @param bits Bitmask of flags to enable
+     */
     inline void setBits(uint8_t /*bits*/);
+
+    /**
+     * @brief Clears specific flag bits.
+     * @param bits Bitmask of flags to disable
+     */
     inline void unsetBits(uint8_t /*bits*/);
+
+    /**
+     * @brief Checks if any of specified flag bits are set.
+     * @param bits Bitmask to test
+     * @return True if any bit in mask is set
+     */
     [[nodiscard]] inline auto anyBitSet(uint8_t /*bits*/) const -> bool;
 
-    void insertIntoDatabase() const noexcept;
-    void removeFromDatabase() const noexcept;
-    void updateDatabaseField() const noexcept;
-    void updateDatabaseItems() const noexcept;
-    void updateDatabaseWarp() const noexcept;
-    void loadDatabaseWarp() noexcept;
-    void loadDatabaseItems() noexcept;
+    void insertIntoDatabase() const noexcept; ///< Adds new field to database
+    void removeFromDatabase() const noexcept; ///< Deletes field from database
+    void updateDatabaseField() const noexcept; ///< Updates tile and music in database
+    void updateDatabaseItems() const noexcept; ///< Syncs item stack to database
+    void updateDatabaseWarp() const noexcept; ///< Syncs warp destination to database
+    void loadDatabaseWarp() noexcept; ///< Loads warp data from database
+    void loadDatabaseItems() noexcept; ///< Loads items and containers from database
 };
 
+/**
+ * @brief Sends field update to all players who can see it.
+ * @param pos Position of field to update
+ *
+ * Notifies clients about tile, item, or character changes on the field.
+ */
 void updateFieldToPlayersInScreen(const position &pos);
 
 } // namespace map

--- a/src/netinterface/BasicCommand.hpp
+++ b/src/netinterface/BasicCommand.hpp
@@ -20,23 +20,39 @@
 #define CBASICCOMMAND_HPP
 
 /**
- *@ingroup Netinterface
- *Basic class for commands which can be sent to a client or received by the server,
- *holding a unique byte to identify the command.
+ * @ingroup Netinterface
+ * @brief Base class for all network commands exchanged between client and server.
+ * 
+ * BasicCommand provides the foundation for the command pattern used in network
+ * communication. Each command type has a unique identifier byte used for:
+ * - Command type identification during deserialization
+ * - Protocol version compatibility checking
+ * - Message routing and dispatch
+ * 
+ * Derived classes include:
+ * - BasicClientCommand: Commands sent from client to server
+ * - BasicServerCommand: Commands sent from server to client
+ * 
+ * @see BasicClientCommand
+ * @see BasicServerCommand
+ * @see CommandFactory
  */
 class BasicCommand {
 private:
-    unsigned char definitionByte; /*<Unique command id*/
+    unsigned char definitionByte; ///< Unique command type identifier
+
 public:
     /**
-     *Constructor which sets the definition byte
-     *\param defByte A unique command id
+     * @brief Creates a command with a specific type identifier.
+     * 
+     * @param defByte Unique command ID byte
      */
     explicit BasicCommand(unsigned char defByte);
 
     /**
-     *Provides read access to the definition byte
-     *\return The unique command id
+     * @brief Gets the command type identifier.
+     * 
+     * @return Unique command ID byte
      */
     [[nodiscard]] auto getDefinitionByte() const -> unsigned char { return definitionByte; };
 };

--- a/src/netinterface/ByteBuffer.hpp
+++ b/src/netinterface/ByteBuffer.hpp
@@ -24,17 +24,33 @@
 #include <cstdint>
 #include <mutex>
 
-constexpr int RECV_BUFFERSIZE = 100;
-constexpr int NUMBEROFBUFFERS = 12;
+constexpr int RECV_BUFFERSIZE = 100; ///< Size of each buffer segment in bytes
+constexpr int NUMBEROFBUFFERS = 12; ///< Total number of ring buffer segments
 
 /**
- *@ingroup Netinterface
- * a thread safe ring buffer. Holds the data which is received from the socket
- * and stores it in 12 sections of 100 bytes each.
- * it guarantees that the read buffer cannot be in front of the write buffer
+ * @brief Thread-safe ring buffer for network data reception.
+ * @ingroup Netinterface
+ *
+ * Provides lock-free concurrent access for network reading and command processing:
+ * - Network thread writes incoming socket data to write buffer
+ * - Command processing thread reads from read buffer
+ * - Ring structure with 12 segments of 100 bytes each (1200 bytes total)
+ * - Atomic operations ensure read buffer never overtakes write buffer
+ *
+ * Buffer lifecycle:
+ * 1. Network thread fills current write buffer
+ * 2. Calls writeToBuf() to commit and advance write position
+ * 3. Processing thread calls getByte() to read sequentially
+ * 4. When read buffer exhausted, automatically advances to next segment
+ *
+ * @note Lock-free design minimizes contention between network I/O and game logic
+ * @note Buffer full condition (write catches up to read) causes writeToBuf() to fail
  */
 class ByteBuffer {
 public:
+    /**
+     * @brief Constructs buffer with all segments marked empty.
+     */
     ByteBuffer();
     ByteBuffer(const ByteBuffer &) = delete;
     auto operator=(const ByteBuffer &) -> ByteBuffer & = delete;
@@ -43,47 +59,56 @@ public:
     ~ByteBuffer() = default;
 
     /**
-     * struct which represens the internal structur of the buffer
+     * @brief Internal structure representing one buffer segment.
      */
     using t_rbuffer = struct {
-        uint16_t fill; /*<how much data is currently in this buffer section*/
-        std::array<unsigned char, RECV_BUFFERSIZE> buff;
+        uint16_t fill; ///< Number of valid bytes currently in this segment
+        std::array<unsigned char, RECV_BUFFERSIZE> buff; ///< Raw data storage
     };
 
     /**
-     * adds the size of bytes which was written in the current write buff and sets the new write buffer
-     * @param size how many bytes are written to the Buffer
-     * @return true if the writing was successfull and a new empty write buffer is ready otherwise false
+     * @brief Commits data to current write buffer and advances to next segment.
+     * @param size Number of bytes written to the buffer (must be <= RECV_BUFFERSIZE)
+     * @return True if commit successful and new write buffer available, false if buffer full
+     *
+     * Atomically updates buffer metadata and advances write position. Returns false
+     * if the next write buffer would collide with the current read buffer.
+     *
+     * @note Called by network thread after filling buffer with socket data
      */
     auto writeToBuf(uint16_t size) -> bool;
 
     /**
-     * returns one byte from the buffer
-     * @return the byte from the buffer
+     * @brief Reads and removes one byte from the buffer.
+     * @return The next byte in sequence, or 0 if buffer empty
+     *
+     * Automatically advances to next read buffer segment when current exhausted.
+     * Thread-safe for concurrent access with writeToBuf().
      */
     auto getByte() -> unsigned char;
 
     /**
-     * return how much data is available in the buffer
-     * @return the number of bytes which are currently in the buffer
+     * @brief Returns total unread bytes across all buffer segments.
+     * @return Number of bytes available for reading
      */
     [[nodiscard]] auto dataAvailable() const -> uint16_t;
 
 private:
     /**
-     * gets a new and empty readBuffer
-     * @return true if there is a new readBuffer available otherwise false so we have to wait for some data to be read
-     * before we can try it again
+     * @brief Advances to next buffer segment for reading.
+     * @return True if new read buffer available, false if caught up to write buffer
+     *
+     * Uses try_lock to avoid blocking if write operation in progress.
      */
     auto getReadBuffer() -> bool;
 
-    std::mutex vlock;           /*<mutex for thread safety*/
-    uint16_t bytesAvailable{0}; /*<stores how much bytes are currently in the buffer*/
+    std::mutex vlock; ///< Mutex protecting buffer structure modifications
+    uint16_t bytesAvailable{0}; ///< Cached count of total readable bytes
 
-    std::atomic_uint8_t rBuff{0};                        /*<number of current read buffer*/
-    std::atomic_uint8_t wBuff{1};                        /*<number of the current write buffer*/
-    std::atomic_uint16_t readPos{0};                     /*<current reading position inside the read buffer*/
-    std::array<t_rbuffer, NUMBEROFBUFFERS> recvBuffer{}; /*<internal buffer collection*/
+    std::atomic_uint8_t rBuff{0}; ///< Current read buffer index (0-11)
+    std::atomic_uint8_t wBuff{1}; ///< Current write buffer index (0-11)
+    std::atomic_uint16_t readPos{0}; ///< Byte position within current read buffer
+    std::array<t_rbuffer, NUMBEROFBUFFERS> recvBuffer{}; ///< Ring buffer segments
 };
 
 #endif

--- a/src/netinterface/CommandFactory.hpp
+++ b/src/netinterface/CommandFactory.hpp
@@ -25,23 +25,43 @@
 #include <unordered_map>
 
 /**
- *factory class which holds templates of BasicServerCommand classes
- *an returns an empty command given by an id
+ * @brief Factory for creating client command instances from network protocol IDs.
+ *
+ * Maintains a registry of command templates indexed by protocol byte identifiers.
+ * When a command byte is received from the network, the factory clones the
+ * corresponding template to create a new command instance ready for data parsing.
+ *
+ * This pattern allows:
+ * - Fast command instantiation without complex switch statements
+ * - Easy addition of new command types
+ * - Separation of command structure from instantiation logic
+ *
+ * @note Constructor pre-registers all game and admin command types
+ * @see BasicClientCommand for the command base class
  */
 class CommandFactory {
 public:
+    /**
+     * @brief Constructs factory and registers all known command types.
+     *
+     * Pre-populates the template list with instances of all client commands
+     * including player actions (movement, combat, chat) and admin commands
+     * (warp, attribute changes, broadcasts).
+     */
     CommandFactory();
 
     /**
-     *returns a pointer to an emtpy Server Command
-     *@param commandId the id of the command which we want to use
-     *@return a pointer to an empty command with the given commandId
+     * @brief Creates a new command instance for the given protocol ID.
+     * @param commandId Network protocol byte identifying the command type
+     * @return Shared pointer to new command instance, or null if ID unknown
+     *
+     * Returns a clone of the registered template for thread-safe reuse.
      */
     auto getCommand(unsigned char commandId) -> ClientCommandPointer;
 
 private:
     using COMMANDLIST = std::unordered_map<unsigned char, std::unique_ptr<BasicClientCommand>>;
-    COMMANDLIST templateList;
+    COMMANDLIST templateList; ///< Map of protocol IDs to command templates
 };
 
 #endif

--- a/src/netinterface/NetInterface.hpp
+++ b/src/netinterface/NetInterface.hpp
@@ -40,23 +40,54 @@ class LoginCommandTS;
 
 /**
  * @defgroup Netinterface Network Interface
- * This is the interface for server client communication.
+ * This is the interface for server-client communication over TCP/IP.
+ * 
+ * The network layer handles:
+ * - Asynchronous socket I/O using Boost.Asio
+ * - Command serialization and deserialization
+ * - Send and receive queues
+ * - Connection lifecycle management
+ * - Client authentication
  */
 
 /**
- *@ingroup Netinterface
- *class which holds the network interface and its thread for sending and receiving data
+ * @ingroup Netinterface
+ * @brief Manages network communication with a single game client.
+ * 
+ * NetInterface handles asynchronous TCP/IP communication with one connected client,
+ * providing:
+ * - Asynchronous message reading and writing using Boost.Asio
+ * - Command queue management for outgoing messages
+ * - Header parsing and CRC validation
+ * - Connection state tracking
+ * - Player association after login
+ * - Graceful connection shutdown
+ * 
+ * Each NetInterface instance corresponds to one active client connection. Messages
+ * are structured with a 6-byte header containing command ID, length, and CRC,
+ * followed by variable-length payload data.
+ * 
+ * The interface operates in two modes:
+ * 1. Pre-login: Only accepts LoginCommandTS, connection closes after processing
+ * 2. Active: Processes all commands and associates with a Player object
+ * 
+ * @note NetInterface is non-copyable and non-movable
+ * @see Player for client game state
+ * @see CommandFactory for command deserialization
  */
 class NetInterface : public std::enable_shared_from_this<NetInterface> {
 public:
     /**
-     * standard constructor, creates the two thread class receiver and sender
+     * @brief Creates a network interface for a new client connection.
+     * 
+     * @param io_servicen Boost.Asio I/O service for async operations
      */
     explicit NetInterface(boost::asio::io_service &io_servicen);
 
     /**
-     * destructor deletes all the classes which are constructed in the constructor
-     * WARNING: shoudln't be called before the threads stopped correctly
+     * @brief Destructor that closes socket and clears queues.
+     * 
+     * @warning Should only be called after async operations have stopped
      */
     ~NetInterface();
 
@@ -65,62 +96,123 @@ public:
     NetInterface(NetInterface &&) = delete;
     auto operator=(NetInterface &&) -> NetInterface & = delete;
 
-    void closeConnection(); /*<closes the connection to the client*/
-    auto activate(Player * /*player*/ = nullptr)
-            -> bool; /*<activates the connection starts the sending and receiving threads, if player == nullptr only
-                        login command is accepted and processing stops afterwards*/
+    /**
+     * @brief Marks the connection as closed, stopping further I/O.
+     */
+    void closeConnection();
+    
+    /**
+     * @brief Activates the connection and begins async read operations.
+     * 
+     * If player is nullptr, only LoginCommandTS is accepted and the connection
+     * closes after receiving it. Otherwise, all commands are processed and
+     * forwarded to the player.
+     * 
+     * @param player The Player object to associate with this connection (nullptr for login-only mode)
+     * @return true if activation successful, false on error
+     */
+    auto activate(Player * /*player*/ = nullptr) -> bool;
+    
+    /**
+     * @brief Increments inactive counter and checks if connection timed out.
+     * 
+     * @return true if connection should be considered inactive/timed out
+     */
     auto nextInactive() -> bool;
 
     /**
-     * adds a command to the send queue so it will be sended correctly to the connection
-     * @param command the command which should be added
+     * @brief Adds a server command to the outgoing send queue.
+     * 
+     * Commands are sent asynchronously in FIFO order.
+     * 
+     * @param command The command to send to the client
      */
     void addCommand(const ServerCommandPointer &command);
 
+    /**
+     * @brief Sends a final command and initiates graceful connection shutdown.
+     * 
+     * @param command The last command to send before closing
+     */
     void shutdownSend(const ServerCommandPointer &command);
 
+    /**
+     * @brief Gets the client's IP address.
+     * 
+     * @return IP address string (e.g., "192.168.1.100")
+     */
     auto getIPAdress() -> std::string;
 
-    std::atomic_bool online; /*< if connection is active*/
+    std::atomic_bool online; ///< true if connection is active and processing commands
 
-    using SERVERCOMMANDLIST = std::deque<ServerCommandPointer>;
+    using SERVERCOMMANDLIST = std::deque<ServerCommandPointer>; ///< Type for outgoing command queue
 
+    /**
+     * @brief Gets the underlying TCP socket.
+     * 
+     * @return Reference to Boost.Asio socket
+     */
     auto getSocket() -> boost::asio::ip::tcp::socket & { return socket; }
 
+    /**
+     * @brief Gets the login data received during authentication.
+     * 
+     * @return Shared pointer to login command (nullptr if not yet received)
+     */
     auto getLoginData() const -> std::shared_ptr<LoginCommandTS> { return loginData; }
 
 private:
+    /**
+     * @brief Async callback for header read completion.
+     * 
+     * @param error Error code from async read operation
+     */
     void handle_read_header(const boost::system::error_code &error);
+    
+    /**
+     * @brief Async callback for payload data read completion.
+     * 
+     * @param error Error code from async read operation
+     */
     void handle_read_data(const boost::system::error_code &error);
 
+    /**
+     * @brief Async callback for normal write completion.
+     * 
+     * @param error Error code from async write operation
+     */
     void handle_write(const boost::system::error_code &error);
+    
+    /**
+     * @brief Async callback for shutdown write completion.
+     * 
+     * @param error Error code from async write operation
+     */
     void handle_write_shutdown(const boost::system::error_code &error);
 
-    // Buffer for the header of messages
-    static constexpr auto headerSize = 6;
-    static constexpr auto commandPosition = 0;
-    static constexpr auto lengthPosition = 2;
-    static constexpr auto crcPosition = 4;
-    std::array<unsigned char, headerSize> headerBuffer;
+    static constexpr auto headerSize = 6; ///< Size of message header in bytes
+    static constexpr auto commandPosition = 0; ///< Byte offset of command ID in header
+    static constexpr auto lengthPosition = 2; ///< Byte offset of payload length in header
+    static constexpr auto crcPosition = 4; ///< Byte offset of CRC checksum in header
+    std::array<unsigned char, headerSize> headerBuffer; ///< Buffer for reading message headers
 
-    ClientCommandPointer cmd;
-    ServerCommandPointer shutdownCmd;
-    ServerCommandPointer cmdToWrite;
+    ClientCommandPointer cmd; ///< Currently processing client command
+    ServerCommandPointer shutdownCmd; ///< Command to send during shutdown
+    ServerCommandPointer cmdToWrite; ///< Command currently being written to socket
 
-    SERVERCOMMANDLIST sendQueue;
+    SERVERCOMMANDLIST sendQueue; ///< Queue of commands waiting to be sent
 
-    std::string ipadress;
+    std::string ipadress; ///< Client's IP address string
 
-    boost::asio::ip::tcp::socket socket;
+    boost::asio::ip::tcp::socket socket; ///< TCP socket for client connection
 
-    // Factory für Commands vom Client
-    CommandFactory commandFactory;
-    static constexpr auto maxInactive = 1000;
-    uint16_t inactive;
-    std::mutex sendQueueMutex;
-    std::shared_ptr<LoginCommandTS> loginData;
+    CommandFactory commandFactory; ///< Factory for deserializing client commands
+    static constexpr auto maxInactive = 1000; ///< Maximum inactive cycles before timeout
+    uint16_t inactive; ///< Current inactive cycle counter
+    std::mutex sendQueueMutex; ///< Mutex protecting sendQueue access
+    std::shared_ptr<LoginCommandTS> loginData; ///< Login credentials received from client
 
-    Player *owner;
+    Player *owner; ///< Associated player object (nullptr during pre-login)
 };
 
 #endif

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -24,10 +24,29 @@
 #include <string>
 #include <type_traits>
 
+/**
+ * @brief Reads raw bytes from an input stream into a buffer.
+ * @param stream The input file stream to read from.
+ * @param output The buffer to write data into.
+ * @param size The number of bytes to read.
+ */
 inline void readFromStream(std::ifstream &stream, char *output, std::size_t size) { stream.read(output, size); }
 
+/**
+ * @brief Writes raw bytes from a buffer to an output stream.
+ * @param stream The output file stream to write to.
+ * @param input The buffer containing data to write.
+ * @param size The number of bytes to write.
+ */
 inline void writeToStream(std::ofstream &stream, const char *input, std::size_t size) { stream.write(input, size); }
 
+/**
+ * @brief Reads a trivially copyable object from a stream.
+ * @tparam T A trivially copyable type (POD types, simple structs).
+ * @param stream The input file stream to read from.
+ * @param output The object to read data into.
+ * @note This uses memcpy and requires T to be trivially copyable to avoid undefined behavior.
+ */
 template <typename T> void readFromStream(std::ifstream &stream, T &output) {
     static_assert(std::is_trivially_copyable_v<T>); // avoid UB with memcpy
     std::string buffer(sizeof(T), '\0');
@@ -35,6 +54,13 @@ template <typename T> void readFromStream(std::ifstream &stream, T &output) {
     std::memcpy(&output, buffer.data(), sizeof(T));
 }
 
+/**
+ * @brief Writes a trivially copyable object to a stream.
+ * @tparam T A trivially copyable type (POD types, simple structs).
+ * @param stream The output file stream to write to.
+ * @param input The object to write to the stream.
+ * @note This uses memcpy and requires T to be trivially copyable to avoid undefined behavior.
+ */
 template <typename T> void writeToStream(std::ofstream &stream, const T &input) {
     static_assert(std::is_trivially_copyable_v<T>); // avoid UB with memcpy
     std::string buffer(sizeof(T), '\0');

--- a/src/thread_safe_vector.hpp
+++ b/src/thread_safe_vector.hpp
@@ -27,29 +27,67 @@
 #include <mutex>
 #include <thread>
 
+/**
+ * @brief Thread-safe wrapper around std::list providing synchronized access.
+ * @tparam T Element type stored in the list
+ *
+ * Provides a subset of std::list operations with automatic mutex locking
+ * to ensure thread-safe concurrent access. All operations use std::lock_guard
+ * for exception-safe locking.
+ *
+ * Supported operations:
+ * - size(): Get number of elements
+ * - empty(): Check if list is empty
+ * - clear(): Remove all elements
+ * - push_back(): Add element to end
+ * - pop_front(): Remove and return first element
+ *
+ * @note Despite the name, this is actually based on std::list, not std::vector
+ * @note pop_front() will throw if called on empty list (inherited from std::list)
+ */
 template <class T> class thread_safe_vector : public std::list<T> {
 public:
+    /**
+     * @brief Returns number of elements with thread safety.
+     * @return Number of elements in the list
+     */
     inline auto size() -> size_t {
         std::lock_guard<std::mutex> lock(vlock);
         uint16_t s = std::list<T>::size();
         return s;
     }
 
+    /**
+     * @brief Removes all elements with thread safety.
+     */
     inline void clear() {
         std::lock_guard<std::mutex> lock(vlock);
         std::list<T>::clear();
     }
 
+    /**
+     * @brief Appends element to end of list with thread safety.
+     * @param item Element to add
+     */
     inline void push_back(const T &item) {
         std::lock_guard<std::mutex> lock(vlock);
         std::list<T>::push_back(item);
     }
 
+    /**
+     * @brief Checks if list is empty with thread safety.
+     * @return True if list contains no elements
+     */
     inline auto empty() -> bool {
         std::lock_guard<std::mutex> lock(vlock);
         return std::list<T>::empty();
     }
 
+    /**
+     * @brief Removes and returns first element with thread safety.
+     * @return Copy of the first element
+     * @throws std::exception if list is empty
+     */
     inline auto pop_front() -> T {
         std::lock_guard<std::mutex> lock(vlock);
         T item = std::list<T>::front();
@@ -58,7 +96,7 @@ public:
     }
 
 private:
-    std::mutex vlock;
+    std::mutex vlock; ///< Mutex for thread-safe access to list operations
 };
 
 #endif

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -22,82 +22,117 @@
 #include <cstdint>
 #include <string>
 
-using Coordinate = int_fast16_t;
+using Coordinate = int_fast16_t; ///< Type for world coordinates (x, y, z).
 
-using TYPE_OF_ITEM_ID = uint16_t;
-using TYPE_OF_TILE_ID = uint16_t;
-using TYPE_OF_CHARACTER_ID = uint32_t;
-using TYPE_OF_RACE_ID = uint16_t;
-using TYPE_OF_RACE_TYPE_ID = uint16_t;
+// Item and character types
+using TYPE_OF_ITEM_ID = uint16_t;      ///< Item type identifier.
+using TYPE_OF_TILE_ID = uint16_t;      ///< Tile type identifier.
+using TYPE_OF_CHARACTER_ID = uint32_t; ///< Character/Monster unique identifier.
+using TYPE_OF_RACE_ID = uint16_t;      ///< Race identifier.
+using TYPE_OF_RACE_TYPE_ID = uint16_t; ///< Race type identifier.
 
-using TYPE_OF_VOLUME = uint16_t;
-using TYPE_OF_WEIGHT = uint16_t;
-using TYPE_OF_AGINGSPEED = uint8_t;
-using TYPE_OF_BRIGHTNESS = uint8_t;
-using TYPE_OF_WORTH = uint32_t;
-using TYPE_OF_MAX_STACK = uint16_t;
-using TYPE_OF_BUY_STACK = uint16_t;
+// Item properties
+using TYPE_OF_VOLUME = uint16_t;    ///< Item volume.
+using TYPE_OF_WEIGHT = uint16_t;    ///< Item weight.
+using TYPE_OF_AGINGSPEED = uint8_t; ///< How quickly an item ages.
+using TYPE_OF_BRIGHTNESS = uint8_t; ///< Light emitted by an item.
+using TYPE_OF_WORTH = uint32_t;     ///< Monetary value of an item.
+using TYPE_OF_MAX_STACK = uint16_t; ///< Maximum stack size for an item.
+using TYPE_OF_BUY_STACK = uint16_t; ///< Stack size when buying.
 
-using TYPE_OF_ITEMLEVEL = uint8_t;
+using TYPE_OF_ITEMLEVEL = uint8_t; ///< Item level requirement.
 
-using TYPE_OF_ATTACK = uint8_t;
-using TYPE_OF_DEFENCE = uint8_t;
-using TYPE_OF_ACCURACY = uint8_t;
-using TYPE_OF_RANGE = uint8_t;
-using TYPE_OF_WEAPONTYPE = uint8_t;
-using TYPE_OF_POISONSTRENGTH = uint8_t;
+// Weapon properties
+using TYPE_OF_ATTACK = uint8_t;         ///< Attack value.
+using TYPE_OF_DEFENCE = uint8_t;        ///< Defence value.
+using TYPE_OF_ACCURACY = uint8_t;       ///< Accuracy value.
+using TYPE_OF_RANGE = uint8_t;          ///< Weapon range.
+using TYPE_OF_WEAPONTYPE = uint8_t;     ///< Weapon type identifier.
+using TYPE_OF_POISONSTRENGTH = uint8_t; ///< Poison strength.
 
-using TYPE_OF_BODYPARTS = uint8_t;
-using TYPE_OF_STROKEARMOR = uint8_t;
-using TYPE_OF_PUNCTUREARMOR = uint8_t;
-using TYPE_OF_THRUSTARMOR = uint8_t;
-using TYPE_OF_MAGICDISTURBANCE = uint16_t;
-using TYPE_OF_ARMORTYPE = uint8_t;
+// Armor properties
+using TYPE_OF_BODYPARTS = uint8_t;         ///< Body parts covered by armor.
+using TYPE_OF_STROKEARMOR = uint8_t;       ///< Protection against slashing damage.
+using TYPE_OF_PUNCTUREARMOR = uint8_t;     ///< Protection against piercing damage.
+using TYPE_OF_THRUSTARMOR = uint8_t;       ///< Protection against bludgeoning damage.
+using TYPE_OF_MAGICDISTURBANCE = uint16_t; ///< Magic interference from armor.
+using TYPE_OF_ARMORTYPE = uint8_t;         ///< Armor type identifier.
 
-using TYPE_OF_CONTAINERSLOTS = uint16_t;
+using TYPE_OF_CONTAINERSLOTS = uint16_t; ///< Number of slots in a container.
 
-using TYPE_OF_WALKINGCOST = uint16_t;
+using TYPE_OF_WALKINGCOST = uint16_t; ///< Movement cost for terrain.
 
-using TYPE_OF_SPECIALITEM = uint8_t;
-using TYPE_OF_AMMUNITIONTYPE = uint8_t;
-using TYPE_OF_ACTIONPOINTS = uint8_t;
+using TYPE_OF_SPECIALITEM = uint8_t;    ///< Special item flag.
+using TYPE_OF_AMMUNITIONTYPE = uint8_t; ///< Ammunition type identifier.
+using TYPE_OF_ACTIONPOINTS = uint8_t;   ///< Action points required.
 
-using TYPE_OF_SKILL_ID = uint8_t;
+using TYPE_OF_SKILL_ID = uint8_t; ///< Skill identifier.
 
-using TYPE_OF_QUEST_ID = uint16_t;
-using TYPE_OF_QUESTSTATUS = int32_t;
+using TYPE_OF_QUEST_ID = uint16_t;   ///< Quest identifier.
+using TYPE_OF_QUESTSTATUS = int32_t; ///< Quest status/progress value.
 
-using TYPE_OF_GERMAN = std::string;
-using TYPE_OF_ENGLISH = std::string;
+using TYPE_OF_GERMAN = std::string;  ///< German language string.
+using TYPE_OF_ENGLISH = std::string; ///< English language string.
 
+/**
+ * @brief Cardinal and vertical movement directions.
+ */
 enum direction {
-    dir_north = 0,
-    dir_northeast = 1,
-    dir_east = 2,
-    dir_southeast = 3,
-    dir_south = 4,
-    dir_southwest = 5,
-    dir_west = 6,
-    dir_northwest = 7,
-    dir_up = 8,
-    dir_down = 9,
-    dir_none = 10
+    dir_north = 0,     ///< North direction.
+    dir_northeast = 1, ///< Northeast direction.
+    dir_east = 2,      ///< East direction.
+    dir_southeast = 3, ///< Southeast direction.
+    dir_south = 4,     ///< South direction.
+    dir_southwest = 5, ///< Southwest direction.
+    dir_west = 6,      ///< West direction.
+    dir_northwest = 7, ///< Northwest direction.
+    dir_up = 8,        ///< Upward direction (z-axis).
+    dir_down = 9,      ///< Downward direction (z-axis).
+    dir_none = 10      ///< No direction/invalid.
 };
 
-constexpr auto minDirection = 0;
-constexpr auto maxDirection = 7;
+constexpr auto minDirection = 0; ///< Minimum valid horizontal direction value.
+constexpr auto maxDirection = 7; ///< Maximum valid horizontal direction value.
 
-enum class movement_type { walk = 0, fly = 1, crawl = 2 };
+/**
+ * @brief Types of character movement.
+ */
+enum class movement_type {
+    walk = 0, ///< Walking on ground.
+    fly = 1,  ///< Flying above ground.
+    crawl = 2 ///< Crawling/swimming.
+};
 
+/**
+ * @brief RGBA color representation.
+ */
 struct Colour {
-    static constexpr uint8_t maxColourValue = 0xFF;
-    uint8_t red = maxColourValue;
-    uint8_t green = maxColourValue;
-    uint8_t blue = maxColourValue;
-    uint8_t alpha = maxColourValue;
+    static constexpr uint8_t maxColourValue = 0xFF; ///< Maximum value for each color component (255).
+    uint8_t red = maxColourValue;                   ///< Red component (0-255).
+    uint8_t green = maxColourValue;                 ///< Green component (0-255).
+    uint8_t blue = maxColourValue;                  ///< Blue component (0-255).
+    uint8_t alpha = maxColourValue;                 ///< Alpha/transparency component (0-255).
 
+    /**
+     * @brief Default constructor creating white color (255, 255, 255, 255).
+     */
     Colour() = default;
+
+    /**
+     * @brief Constructs an opaque color with specified RGB values.
+     * @param red Red component (0-255).
+     * @param green Green component (0-255).
+     * @param blue Blue component (0-255).
+     */
     Colour(uint8_t red, uint8_t green, uint8_t blue) : red(red), green(green), blue(blue) {}
+
+    /**
+     * @brief Constructs a color with specified RGBA values.
+     * @param red Red component (0-255).
+     * @param green Green component (0-255).
+     * @param blue Blue component (0-255).
+     * @param alpha Alpha/transparency component (0-255).
+     */
     Colour(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)
             : red(red), green(green), blue(blue), alpha(alpha) {}
 };

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -21,15 +21,54 @@
 
 #include "types.hpp"
 
+/**
+ * @brief Case-insensitive character comparison predicate.
+ * @param c1 First character to compare.
+ * @param c2 Second character to compare.
+ * @return true if characters are equal (ignoring case), false otherwise.
+ */
 extern auto mypred(char c1, char c2) -> bool;
+
+/**
+ * @brief Case-insensitive string comparison.
+ * @param s1 First string to compare.
+ * @param s2 Second string to compare.
+ * @return true if strings are equal (ignoring case), false otherwise.
+ */
 extern auto comparestrings_nocase(const std::string &s1, const std::string &s2) -> bool;
+
+/**
+ * @brief Converts a numeric direction value to a direction enum.
+ * @param dir The numeric direction value to convert.
+ * @return The corresponding direction enum value, or dir_none if out of range.
+ */
 extern auto to_direction(uint8_t dir) -> direction;
+
+/**
+ * @brief Checks if a string contains only numeric digits.
+ * @param str The string to check.
+ * @return true if the string is non-empty and contains only digits 0-9, false otherwise.
+ */
 extern auto isNumeric(const std::string &str) -> bool;
 
+/**
+ * @brief A simple iterator range wrapper for use with range-based for loops.
+ * @tparam T An iterator type.
+ */
 template <class T> struct iterator_range {
+    /**
+     * @brief Returns the beginning iterator.
+     * @return The first iterator in the range.
+     */
     [[nodiscard]] auto begin() const -> T { return p.first; }
+
+    /**
+     * @brief Returns the ending iterator.
+     * @return The last iterator in the range.
+     */
     [[nodiscard]] auto end() const -> T { return p.second; }
-    std::pair<T, T> p;
+
+    std::pair<T, T> p; ///< The pair of iterators defining the range.
 };
 
 #endif


### PR DESCRIPTION
## Intent

This changeset attempts to document the full codebase by adding Doxygen's docblocks to each `.hpp` file. Please note that the vast majority of this documentation is written by Claude Opus 4.5, prompted to thoroughly document the headers while referring to any necessary implementation files for reference.

The goal here is *usable* documentation that can be used by editors' Intellisense to remind a developer about what functions/variables/etc do what, and why they do it.

I realize that this is a *massive* set of changes, and am under no illusions that this will make its way right into the codebase. If you've got the time, let's work through this together.

## Example screenshot

<img width="2804" height="1865" alt="image" src="https://github.com/user-attachments/assets/a6c3428b-35b5-4c9c-9ee7-f0cedd87fe2d" />
